### PR TITLE
disable upower by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,6 @@ MAINTAINERCLEANFILES = \
 	$(srcdir)/m4/intltool.m4 \
 	`find "$(srcdir)" -type f -name Makefile.in -print`
 
-DISTCHECK_CONFIGURE_FLAGS = --disable-upower
+DISTCHECK_CONFIGURE_FLAGS = --disable-old-upower
 
 -include $(top_srcdir)/git.mk

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,6 @@ AC_MSG_RESULT([$with_gtk])
 GLIB_REQUIRED=2.36.0
 GIO_REQUIRED=2.25.0
 DBUS_GLIB_REQUIRED=0.76
-UPOWER_REQUIRED=0.9.0
 MATE_DESKTOP_REQUIRED=1.9.2
 
 case "$with_gtk" in
@@ -131,23 +130,24 @@ AC_SUBST(HAVE_SYSTEMD)
 dnl ====================================================================
 dnl UPOWER
 dnl ====================================================================
-
-AC_ARG_ENABLE(upower,
-              AS_HELP_STRING([--enable-upower],
+dnl We can only support old upower
+dnl https://bugzilla.gnome.org/show_bug.cgi?id=710383
+AC_ARG_ENABLE(old-upower,
+              AS_HELP_STRING([--enable-old-upower],
               [Use upower to suspend/hibernate]),
-              enable_upower=$enableval,
-              enable_upower=yes)
-if test "x$enable_upower" = "xyes"; then
-    PKG_CHECK_MODULES(UPOWER, upower-glib >= $UPOWER_REQUIRED, has_upower=yes, has_upower=no)
+              enable_old_upower=$enableval,
+              enable_old_upower=no)
+if test "x$enable_old_upower" = "xyes"; then
+    PKG_CHECK_MODULES(UPOWER, upower-glib <= 0.9.23, have_old_upower=yes, have_old_upower=no)
 
-    if test "x$has_upower" = "xyes"; then
-        AC_DEFINE(HAVE_UPOWER, 1, [upower support])
+    if test "x$have_old_upower" = "xyes"; then
+        AC_DEFINE(HAVE_OLD_UPOWER, 1, [legacy upower support])
         AC_SUBST(UPOWER_CFLAGS)
         AC_SUBST(UPOWER_LIBS)
     fi
 fi
-AM_CONDITIONAL(HAVE_UPOWER, test "x$has_upower" = "xyes")
-AC_SUBST(HAVE_UPOWER)
+AM_CONDITIONAL(HAVE_OLD_UPOWER, test "x$has_old_upower" = "xyes")
+AC_SUBST(HAVE_OLD_UPOWER)
 
 dnl ====================================================================
 dnl X development libraries check
@@ -407,7 +407,7 @@ echo "
         GTK+ version:             ${with_gtk}
         Default WM:               ${with_default_wm}
         Systemd support:          ${use_systemd}
-        Upower support:           ${enable_upower}
+        Legacy Upower support:    ${have_old_upower}
         IPv6 support:             ${have_full_ipv6}
         Backtrace support:        ${have_backtrace}
         XRender support:          ${have_xrender}

--- a/mate-session/gsm-manager.c
+++ b/mate-session/gsm-manager.c
@@ -38,7 +38,8 @@
 #include <dbus/dbus-glib.h>
 #include <dbus/dbus-glib-lowlevel.h>
 
-#ifdef HAVE_UPOWER
+#ifdef HAVE_OLD_UPOWER
+#define UPOWER_ENABLE_DEPRECATED 1
 #include <upower.h>
 #endif
 
@@ -146,7 +147,7 @@ struct GsmManagerPrivate
 
         DBusGProxy             *bus_proxy;
         DBusGConnection        *connection;
-#ifdef HAVE_UPOWER
+#ifdef HAVE_OLD_UPOWER
         /* Interface with other parts of the system */
         UpClient               *up_client;
 #endif
@@ -1133,7 +1134,7 @@ manager_perhaps_lock (GsmManager *manager)
 static void
 manager_attempt_hibernate (GsmManager *manager)
 {
-#ifdef HAVE_UPOWER
+#ifdef HAVE_OLD_UPOWER
         gboolean  can_hibernate;
         GError   *error;
         gboolean  ret;
@@ -1151,10 +1152,10 @@ manager_attempt_hibernate (GsmManager *manager)
                 gsm_systemd_attempt_hibernate (systemd);
         }
 #endif
-#if defined(HAVE_SYSTEMD) && defined(HAVE_UPOWER)
+#if defined(HAVE_SYSTEMD) && defined(HAVE_OLD_UPOWER)
         else {
 #endif
-#ifdef HAVE_UPOWER
+#ifdef HAVE_OLD_UPOWER
         can_hibernate = up_client_get_can_hibernate (manager->priv->up_client);
         if (can_hibernate) {
 
@@ -1170,7 +1171,7 @@ manager_attempt_hibernate (GsmManager *manager)
                 }
         }
 #endif
-#if defined(HAVE_SYSTEMD) && defined(HAVE_UPOWER)
+#if defined(HAVE_SYSTEMD) && defined(HAVE_OLD_UPOWER)
         }
 #endif
 }
@@ -1178,7 +1179,7 @@ manager_attempt_hibernate (GsmManager *manager)
 static void
 manager_attempt_suspend (GsmManager *manager)
 {
-#ifdef HAVE_UPOWER
+#ifdef HAVE_OLD_UPOWER
         gboolean  can_suspend;
         GError   *error;
         gboolean  ret;
@@ -1196,10 +1197,10 @@ manager_attempt_suspend (GsmManager *manager)
                 gsm_systemd_attempt_suspend (systemd);
         }
 #endif
-#if defined(HAVE_SYSTEMD) && defined(HAVE_UPOWER)
+#if defined(HAVE_SYSTEMD) && defined(HAVE_OLD_UPOWER)
         else {
 #endif
-#ifdef HAVE_UPOWER
+#ifdef HAVE_OLD_UPOWER
         can_suspend = up_client_get_can_suspend (manager->priv->up_client);
         if (can_suspend) {
 
@@ -1215,7 +1216,7 @@ manager_attempt_suspend (GsmManager *manager)
                 }
         }
 #endif
-#if defined(HAVE_SYSTEMD) && defined(HAVE_UPOWER)
+#if defined(HAVE_SYSTEMD) && defined(HAVE_OLD_UPOWER)
         }
 #endif
 }
@@ -2388,7 +2389,7 @@ gsm_manager_dispose (GObject *object)
                 g_object_unref (manager->priv->settings_screensaver);
                 manager->priv->settings_screensaver = NULL;
         }
-#ifdef HAVE_UPOWER
+#ifdef HAVE_OLD_UPOWER
         if (manager->priv->up_client != NULL) {
                 g_object_unref (manager->priv->up_client);
                 manager->priv->up_client = NULL;
@@ -2600,7 +2601,7 @@ gsm_manager_init (GsmManager *manager)
                           "status-changed",
                           G_CALLBACK (on_presence_status_changed),
                           manager);
-#ifdef HAVE_UPOWER
+#ifdef HAVE_OLD_UPOWER
         manager->priv->up_client = up_client_new ();
 #endif
         g_signal_connect (manager->priv->settings_session,
@@ -3271,7 +3272,7 @@ gsm_manager_can_shutdown (GsmManager *manager,
 #endif
         gboolean can_suspend;
         gboolean can_hibernate;
-#ifdef HAVE_UPOWER
+#ifdef HAVE_OLD_UPOWER
         g_object_get (manager->priv->up_client,
                       "can-suspend", &can_suspend,
                       "can-hibernate", &can_hibernate,


### PR DESCRIPTION
suspend/hibernate support removed in upower 0.99.0, we can use these with upower <= 0.9.23 only.
