### PR TITLE
Set XDG_CURRENT_DESKTOP if unset

### DIFF
--- a/mate-session/main.c
+++ b/mate-session/main.c
@@ -597,6 +597,9 @@ int main(int argc, char** argv)
 	mdm_log_init();
 	mdm_log_set_debug(debug);
 
+	if (g_getenv ("XDG_CURRENT_DESKTOP") == NULL)
+		gsm_util_setenv ("XDG_CURRENT_DESKTOP", "MATE");
+
 	/* Set DISPLAY explicitly for all our children, in case --display
 	 * was specified on the command line.
 	 */


### PR DESCRIPTION
XDG_CURRENT_DESKTOP is used by glib >= 2.42 at g_desktop_app_info\* functions
