### PR TITLE
gtk-3.14: invisible session properties dialog

### DIFF
--- a/capplet/gsm-app-dialog.c
+++ b/capplet/gsm-app-dialog.c
@@ -255,6 +255,10 @@ gsm_app_dialog_constructor (GType                  type,
 
         setup_dialog (dialog);
 
+#if !GTK_CHECK_VERSION (3, 14, 0)
+        gtk_widget_show_all (GTK_WIDGET (dialog));
+#endif
+
         return G_OBJECT (dialog);
 }
 

--- a/capplet/gsm-properties-dialog.c
+++ b/capplet/gsm-properties-dialog.c
@@ -702,6 +702,10 @@ gsm_properties_dialog_constructor (GType                  type,
 
         setup_dialog (dialog);
 
+#if !GTK_CHECK_VERSION (3, 14, 0)
+        gtk_widget_show (GTK_WIDGET (dialog));
+#endif
+
         return G_OBJECT (dialog);
 }
 


### PR DESCRIPTION
fix invisible session properties dialog when running with gtk-3.14
