### PR TITLE
[1.8] avoid dereferencing NULL pointer

### DIFF
--- a/mate-session/main.c
+++ b/mate-session/main.c
@@ -249,15 +249,16 @@ static void append_required_apps(GsmManager* manager)
 	{
 		g_warning("No required applications specified");
 	}
-
-	for (i = 0; required_components[i]; i++)
+	else
 	{
+		for (i = 0; required_components[i]; i++)
+		{
 			char* default_provider;
 			const char* component;
 
 			if (IS_STRING_EMPTY((char*) required_components[i]))
 			{
-					continue;
+				continue;
 			}
 
 			component = required_components[i];
@@ -285,6 +286,7 @@ static void append_required_apps(GsmManager* manager)
 			}
 
 			g_free(default_provider);
+		}
 	}
 
 	g_debug("main: *** Done adding required apps");


### PR DESCRIPTION
backport of https://github.com/mate-desktop/mate-session-manager/pull/68 to 1.8 branch