### PR TITLE
[1.8] first connect to settings, then read them.

### DIFF
--- a/capplet/gsm-properties-dialog.c
+++ b/capplet/gsm-properties-dialog.c
@@ -671,13 +671,14 @@ setup_dialog (GsmPropertiesDialog *dialog)
         button = GTK_WIDGET (gtk_builder_get_object (dialog->priv->xml,
                                                      CAPPLET_REMEMBER_WIDGET_NAME));
         dialog->priv->remember_toggle = button;
-        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (button),
-                                      g_settings_get_boolean (dialog->priv->settings, SPC_AUTOSAVE_KEY));
+
         g_signal_connect (dialog->priv->settings,
                           "changed::" SPC_AUTOSAVE_KEY,
                           G_CALLBACK (on_autosave_value_notify),
                           dialog);
 
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (button),
+                                      g_settings_get_boolean (dialog->priv->settings, SPC_AUTOSAVE_KEY));
         g_signal_connect (button,
                           "toggled",
                           G_CALLBACK (on_autosave_value_toggled),

--- a/mate-session/gsm-autostart-app.c
+++ b/mate-session/gsm-autostart-app.c
@@ -307,12 +307,13 @@ setup_gsettings_condition_monitor (GsmAutostartApp *app,
                 return FALSE;
 
         settings = g_settings_new (elems[0]);
-        retval = g_settings_get_boolean (settings, elems[1]);
 
         signal = g_strdup_printf ("changed::%s", elems[1]);
         g_signal_connect (G_OBJECT (settings), signal,
                           G_CALLBACK (gsettings_condition_cb), app);
         g_free (signal);
+
+        retval = g_settings_get_boolean (settings, elems[1]);
 
         app->priv->condition_settings = settings;
 


### PR DESCRIPTION
fixes the issue with GLib >= 2.43,
https://git.gnome.org/browse/glib/commit/?id=8ff5668a458344da22d30491e3ce726d861b3619