### PR TITLE
RFC: Add option to disable/enable overlay scrolling

### DIFF
--- a/mate-session/msm-gnome.c
+++ b/mate-session/msm-gnome.c
@@ -43,6 +43,8 @@
 
 #define GSM_SCHEMA "org.mate.session"
 #define GSM_GNOME_COMPAT_STARTUP_KEY "gnome-compat-startup"
+#define MATE_INTERFACE_SCHEMA "org.mate.interface"
+#define MATE_GTK_OVERLAY_SCROLL "gtk-overlay-scrolling"
 
 #define GNOME_KEYRING_DAEMON "gnome-keyring-daemon"
 
@@ -222,6 +224,23 @@ msm_compat_gnome_smproxy_shutdown (void)
 #endif
 }
 
+static void
+msm_gtk_set_overlay_scroll (void)
+{
+	GSettings* settings;
+	gboolean   enabled;
+
+	settings = g_settings_new (MATE_INTERFACE_SCHEMA);
+	enabled = g_settings_get_boolean (settings, MATE_GTK_OVERLAY_SCROLL);
+
+	if (enabled) {
+		g_setenv ("GTK_OVERLAY_SCROLLING", "1", TRUE);
+	} else {
+		g_setenv ("GTK_OVERLAY_SCROLLING", "0", TRUE);
+	}
+
+	g_object_unref (settings);
+}
 
 void
 msm_gnome_start (void)
@@ -255,6 +274,8 @@ msm_gnome_start (void)
     g_debug ("MsmGnome: No components found to start");
   }
   g_object_unref (settings);
+
+  msm_gtk_set_overlay_scroll ();
 }
 
 


### PR DESCRIPTION
This is a proof of concept and RFC only.

The recent Gtk3 scrolled window (bar) changes called overlay scrolling is really annoying me. And when @NiceandGently told me it could be disabled I was happy and started experimenting.

Some things still to add and discuss.

 * It should listen to gsettings changes and set the env variable appropriately
 * It overwrites the env variable regardless of what was there before (perhaps set by the user).
 * It has to run early in session start. So my thought was it needs to be in mate-session.
 * Anything else I forgot?

The first is an implementation detail which will be sorted before commit. But the second and third I am not sure.

On the second, should we blindly overwrite the env variable? Maybe it should be a "force old scrollbar" and ignore everything if this is disabled?

On the third, it needs to run early so for simplicity's sake only I it shoved it in msm-gnome. But the general question is should it go in mate-session-manager at all?

ps: The code relies on https://github.com/infirit/mate-desktop/commit/377eed97b112eced8be08a9ce7a2db25e191325d