### PR TITLE
Make QT5 apps follow the GTK style

### DIFF
--- a/mate-session/main.c
+++ b/mate-session/main.c
@@ -631,6 +631,9 @@ int main(int argc, char** argv)
 	 */
 	gsm_util_setenv("MATE_DESKTOP_SESSION_ID", "this-is-deprecated");
 
+	/* Make QT5 apps follow the GTK style */
+	gsm_util_setenv ("QT_STYLE_OVERRIDE", "gtk");
+
 	/*
 	 * Make sure gsettings is set up correctly.  If not, then bail.
 	 */


### PR DESCRIPTION
You can use dropbox systray to test:

- Without this, the menu uses the QT style (white with blue highlight)
- With this, the menu looks like according to your GTK style
