### PR TITLE
Emphasize: logout with mate-save-session does not save

### DIFF
--- a/doc/man/mate-session-save.1
+++ b/doc/man/mate-session-save.1
@@ -10,7 +10,7 @@ mate-session-save \- End or save the current MATE session
 .SH "SYNOPSIS"
 .B mate-session-save [\-\-logout] [\-\-force\-logout] [\-\-logout\-dialog] [\-\-shutdown\-dialog] [\-\-gui] [\-\-kill [\-\-silent]]
 .SH "DESCRIPTION"
-The \fBmate-session-save\fP program can be used from a MATE session to save a snapshot of the currently running applications. This session will be later restored at your next MATE session.
+The \fBmate-session-save\fP program can be used from a MATE session to either end the current MATE session or save a snapshot of the currently running applications (but not both). This session will be later restored at your next MATE session.
 .SH "USAGE"
 The \fB\-\-gui\fP option will report errors in dialog boxes instead of printing to stderr.
 .PP


### PR DESCRIPTION
Revises man page for mate-save-session to emphasize in the opening paragraph that mate-save-session either ends the session or saves it, but not both.

Occasional users of mate-save-session (such as myself) can easily miss that mate-save-session will not save the running applications if you also ask it to end the session. This needs to be emphasized multiple times or it will be missed, and will lead to unnecessary frustrations.