### PR TITLE
Enforce screen locking before requesting switch to a different user.

### DIFF
--- a/mate-session/gsm-manager.c
+++ b/mate-session/gsm-manager.c
@@ -3178,6 +3178,19 @@ logout_dialog_response (GsmLogoutDialog *logout_dialog,
         case GTK_RESPONSE_DELETE_EVENT:
                 break;
         case GSM_LOGOUT_RESPONSE_SWITCH_USER:
+
+                ; /* place an empty statement between label above and declaration below... */
+
+                /* Lock screen before requesting user switch
+                 */
+                GError *error;
+                error = NULL;
+                g_spawn_command_line_async ("mate-screensaver-command --lock", &error);
+                if (error != NULL) {
+                    g_warning ("Couldn't lock screen: %s", error->message);
+                    g_error_free (error);
+                }
+
                 request_switch_user (manager);
                 break;
         case GSM_LOGOUT_RESPONSE_HIBERNATE:


### PR DESCRIPTION
One of my customers noticed that there is a security issue with user switching via the logout dialog.

The session does not get locked when user switching is requested via the logout dialog. However, this should be enforced.

I am not sure if the proposed patch is a generic way of requesting a screen lock. However, the approach works well on mate-session-manager as found in Debian jessie.
