### PR TITLE
require GTK+ >= 3.14, drop GTK+2 code and --with-gtk build option

### DIFF
--- a/capplet/gsm-app-dialog.c
+++ b/capplet/gsm-app-dialog.c
@@ -254,10 +254,6 @@ gsm_app_dialog_constructor (GType                  type,
 
         setup_dialog (dialog);
 
-#if !GTK_CHECK_VERSION (3, 14, 0)
-        gtk_widget_show_all (GTK_WIDGET (dialog));
-#endif
-
         return G_OBJECT (dialog);
 }
 

--- a/capplet/gsm-properties-dialog.c
+++ b/capplet/gsm-properties-dialog.c
@@ -552,9 +552,6 @@ setup_dialog (GsmPropertiesDialog *dialog)
 
         gtk_tree_view_column_set_sort_column_id (column, STORE_COL_DESCRIPTION);
         gtk_tree_view_set_search_column (treeview, STORE_COL_SEARCH);
-#if !GTK_CHECK_VERSION (3, 14, 0)
-        gtk_tree_view_set_rules_hint (treeview, TRUE);
-#endif
 
         gtk_tree_view_enable_model_drag_source (treeview,
                                                 GDK_BUTTON1_MASK|GDK_BUTTON2_MASK,
@@ -660,10 +657,6 @@ gsm_properties_dialog_constructor (GType                  type,
                                                                                                                   construct_properties));
 
         setup_dialog (dialog);
-
-#if !GTK_CHECK_VERSION (3, 14, 0)
-        gtk_widget_show (GTK_WIDGET (dialog));
-#endif
 
         return G_OBJECT (dialog);
 }

--- a/configure.ac
+++ b/configure.ac
@@ -41,29 +41,11 @@ if test "x$enable_deprecations" = "xyes"; then
    AC_SUBST([DISABLE_DEPRECATED_CFLAGS])
 fi
 
-AC_MSG_CHECKING([which gtk+ version to compile against])
-AC_ARG_WITH([gtk],
-  [AS_HELP_STRING([--with-gtk=2.0|3.0],[which gtk+ version to compile against (default: 2.0)])],
-  [case "$with_gtk" in
-     2.0|3.0) ;;
-     *) AC_MSG_ERROR([invalid gtk version specified]) ;;
-   esac],
-  [with_gtk=2.0])
-AC_MSG_RESULT([$with_gtk])
-
 GLIB_REQUIRED=2.36.0
 GIO_REQUIRED=2.25.0
+GTK_REQUIRED=3.14.0
 DBUS_GLIB_REQUIRED=0.76
 UPOWER_REQUIRED=0.9.0
-
-case "$with_gtk" in
-  2.0) GTK_API_VERSION=2.0
-       GTK_REQUIRED=2.24.0
-       ;;
-  3.0) GTK_API_VERSION=3.0
-       GTK_REQUIRED=3.0.0
-       ;;
-esac
 
 dnl ====================================================================
 dnl Dependency Checks
@@ -73,13 +55,13 @@ PKG_PROG_PKG_CONFIG()
 PKG_CHECK_MODULES(MATE_SESSION,
         glib-2.0 >= $GLIB_REQUIRED
         gio-2.0 >= $GIO_REQUIRED
-        gtk+-$GTK_API_VERSION >= $GTK_REQUIRED
+        gtk+-3.0 >= $GTK_REQUIRED
         dbus-glib-1 >= $DBUS_GLIB_REQUIRED
 )
 
 PKG_CHECK_MODULES(SESSION_PROPERTIES,
         glib-2.0 >= $GLIB_REQUIRED
-        gtk+-$GTK_API_VERSION >= $GTK_REQUIRED
+        gtk+-3.0 >= $GTK_REQUIRED
 )
 
 PKG_CHECK_MODULES(X11, x11)
@@ -89,7 +71,7 @@ PKG_CHECK_MODULES(XEXT, xext xau)
 
 PKG_CHECK_MODULES(DBUS_GLIB, dbus-glib-1 >= $DBUS_GLIB_REQUIRED)
 
-PKG_CHECK_MODULES(EGG_SMCLIENT, gtk+-$GTK_API_VERSION)
+PKG_CHECK_MODULES(EGG_SMCLIENT, gtk+-3.0)
 
 
 dnl ====================================================================
@@ -378,7 +360,6 @@ echo "
         Maintainer mode:          ${USE_MAINTAINER_MODE}
         Warn about deprecations:  ${enable_deprecations}
 
-        GTK+ version:             ${with_gtk}
         Default WM:               ${with_default_wm}
         Systemd support:          ${use_systemd}
         Upower support:           ${enable_upower}

--- a/egg/eggsmclient-private.h
+++ b/egg/eggsmclient-private.h
@@ -21,9 +21,6 @@
 #define __EGG_SM_CLIENT_PRIVATE_H__
 
 #include <gtk/gtk.h>
-#if !GTK_CHECK_VERSION (3, 0, 0)
-#include <gdkconfig.h>
-#endif
 #include "eggsmclient.h"
 
 #ifdef __cplusplus

--- a/egg/eggsmclient-xsmp.c
+++ b/egg/eggsmclient-xsmp.c
@@ -366,13 +366,7 @@ sm_client_xsmp_startup (EggSMClient *client,
       xsmp->client_id = g_strdup (ret_client_id);
       free (ret_client_id);
 
-#if !GTK_CHECK_VERSION (3, 0, 0)
-      gdk_threads_enter ();
-#endif
       gdk_x11_set_sm_client_id (xsmp->client_id);
-#if !GTK_CHECK_VERSION (3, 0, 0)
-      gdk_threads_leave ();
-#endif
 
       g_debug ("Got client ID \"%s\"", xsmp->client_id);
     }
@@ -540,10 +534,6 @@ idle_do_pending_events (gpointer data)
   EggSMClientXSMP *xsmp = data;
   EggSMClient *client = data;
 
-#if !GTK_CHECK_VERSION (3, 0, 0)
-  gdk_threads_enter ();
-#endif
-
   xsmp->idle = 0;
 
   if (xsmp->waiting_to_emit_quit)
@@ -567,9 +557,6 @@ idle_do_pending_events (gpointer data)
     }
 
  out:
-#if !GTK_CHECK_VERSION (3, 0, 0)
-  gdk_threads_leave ();
-#endif
   return FALSE;
 }
 
@@ -1291,13 +1278,7 @@ process_ice_messages (IceConn ice_conn)
 {
   IceProcessMessagesStatus status;
 
-#if !GTK_CHECK_VERSION (3, 0, 0)
-  gdk_threads_enter ();
-#endif
   status = IceProcessMessages (ice_conn, NULL, NULL);
-#if !GTK_CHECK_VERSION (3, 0, 0)
-  gdk_threads_leave ();
-#endif
 
   switch (status)
     {

--- a/mate-session/gsm-logout-dialog.c
+++ b/mate-session/gsm-logout-dialog.c
@@ -523,15 +523,9 @@ gsm_get_dialog (GsmDialogLogoutType type,
 
         dialog_image = gtk_message_dialog_get_image (GTK_MESSAGE_DIALOG (logout_dialog));
 
-#if GTK_CHECK_VERSION (3, 0, 0)
         hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
-#else
-        hbox = gtk_hbox_new (FALSE, 0);
-#endif
         logout_dialog->priv->progressbar = gtk_progress_bar_new ();
-#if GTK_CHECK_VERSION (3, 0, 0)
         gtk_progress_bar_set_show_text (GTK_PROGRESS_BAR (logout_dialog->priv->progressbar), TRUE);
-#endif
         gtk_progress_bar_set_fraction (GTK_PROGRESS_BAR (logout_dialog->priv->progressbar), 1.0);
         gtk_box_pack_start (GTK_BOX (hbox),
                             logout_dialog->priv->progressbar,

--- a/mate-session/msm-gnome.c
+++ b/mate-session/msm-gnome.c
@@ -196,11 +196,7 @@ msm_compat_gnome_smproxy_startup (void)
                    (unsigned char *) (void *) &gnome_smproxy_window, 1);
 
   XSync (dpy, False);
-#if GTK_CHECK_VERSION (3, 0, 0)
   gdk_error_trap_pop_ignored ();
-#else
-  gdk_error_trap_pop ();
-#endif
 }
 
 
@@ -215,11 +211,7 @@ msm_compat_gnome_smproxy_shutdown (void)
       XSync (GDK_DISPLAY_XDISPLAY(gdk_display_get_default()), False);
       gnome_smproxy_window = None;
     }
-#if GTK_CHECK_VERSION (3, 0, 0)
   gdk_error_trap_pop_ignored ();
-#else
-  gdk_error_trap_pop ();
-#endif
 }
 
 

--- a/mate-session/test-inhibit.c
+++ b/mate-session/test-inhibit.c
@@ -93,11 +93,7 @@ do_inhibit_for_window (GdkWindow *window)
         app_id = "caja";
         reason = "A file transfer is in progress.";
 #endif
-#if GTK_CHECK_VERSION (3, 0, 0)
         toplevel_xid = gdk_x11_window_get_xid (window);
-#else
-        toplevel_xid = GDK_DRAWABLE_XID (window);
-#endif
 
         flags = GSM_INHIBITOR_FLAG_LOGOUT
                 | GSM_INHIBITOR_FLAG_SWITCH_USER


### PR DESCRIPTION
@flexiondotorg @clefebvre @raveit65 @posophe @XRevan86 @willysr @obache @NP-Hardass

So, now we move m-s-m to GTK+3 as well:

- minimum GTK+ version is set to 3.14
- GTK+2 code and deprecated GTK+3 code are dropped
- ```--with-gtk``` build option is dropped as well
- build-dep on GTK+ dev package is changed (that's what you need to do in your distros)