### PR TITLE
Allow TreeView to expand vertically

### DIFF
--- a/data/session-properties.ui
+++ b/data/session-properties.ui
@@ -44,6 +44,7 @@
                     <property name="height_request">210</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="vexpand">True</property>
                   </object>
                 </child>
               </object>


### PR DESCRIPTION
Resizing the Startup Applications Preferences window vertically does not result in the startup programs list expanding to fill the available space (though horizontal window expansion was filled automatically).

This change was all that appeared necessary to get the startup program listing to expand vertically to fill the resized window.

Tested with Mate 1.16 on CentOS 7.