### PR TITLE
build: check stricter for presence of xtrans

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,12 +243,18 @@ fi
 AC_SUBST(EXECINFO_LIBS)
 
 dnl ====================================================================
-dnl Check for newish X interface
+dnl Check for X transport interface - allows to disable ICE Transports
+dnl See also https://bugzilla.gnome.org/show_bug.cgi?id=725100
 dnl ====================================================================
-oCFLAGS="$CFLAGS"
-CFLAGS="$CFLAGS $X_CFLAGS"
-AC_CHECK_HEADERS(X11/Xtrans/Xtrans.h)
-CFLAGS="$oCFLAGS"
+AC_ARG_WITH([xtrans],
+	    [AS_HELP_STRING([--without-xtrans],
+			   [Build without xtrans support (results in ICE listening on remote TCP ports)])],
+	    [],
+	    [with_xtrans=yes])
+AS_IF([test "$with_xtrans" != "no"],
+      [PKG_CHECK_MODULES(XTRANS, xtrans,
+      [AC_DEFINE(HAVE_XTRANS, 1, [Have the X Transport library])])])
+AC_SUBST(HAVE_XTRANS)
 
 dnl ====================================================================
 dnl Code for checking whether IPv6 is enabled on the system....

--- a/mate-session/gsm-xsmp-server.c
+++ b/mate-session/gsm-xsmp-server.c
@@ -39,14 +39,14 @@
 #include <X11/ICE/ICEconn.h>
 #include <X11/SM/SMlib.h>
 
-#ifdef HAVE_X11_XTRANS_XTRANS_H
+#if HAVE_XTRANS
 /* Get the proto for _IceTransNoListen */
 #define ICE_t
 #define TRANS_SERVER
 #include <X11/Xtrans/Xtrans.h>
 #undef  ICE_t
 #undef TRANS_SERVER
-#endif /* HAVE_X11_XTRANS_XTRANS_H */
+#endif /* HAVE_XTRANS */
 
 #include "gsm-xsmp-server.h"
 #include "gsm-xsmp-client.h"
@@ -560,7 +560,7 @@ setup_listener (GsmXsmpServer *server)
                 gsm_util_init_error (TRUE, "Could not initialize libSM: %s", error);
         }
 
-#ifdef HAVE_X11_XTRANS_XTRANS_H
+#if HAVE_XTRANS
         /* By default, IceListenForConnections will open one socket for each
          * transport type known to X. We don't want connections from remote
          * hosts, so for security reasons it would be best if ICE didn't
@@ -612,7 +612,7 @@ setup_listener (GsmXsmpServer *server)
                 gsm_util_init_error (TRUE, "IceListenForConnections did not return a local listener!");
         }
 
-#ifdef HAVE_X11_XTRANS_XTRANS_H
+#ifdef HAVE_XTRANS
         if (server->priv->num_local_xsmp_sockets != server->priv->num_xsmp_sockets) {
                 /* Xtrans was apparently compiled with support for some
                  * non-local transport besides TCP (which we disabled above); we


### PR DESCRIPTION
this should ensure that mate-session won't listen to TCP ports.
if needed, this check can be disabled using --without-xtrans option.

fixes https://github.com/mate-desktop/mate-session-manager/issues/131

adapted from:
https://git.gnome.org/browse/gnome-session/commit/?id=aa4c9d125012ae94154ce075d62342b63b41a7d9