### PR TITLE
Replace deprecated upower functions with ConsoleKit2 equivalents

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,6 @@ GLIB_REQUIRED=2.36.0
 GIO_REQUIRED=2.25.0
 GTK_REQUIRED=3.14.0
 DBUS_GLIB_REQUIRED=0.76
-UPOWER_REQUIRED=0.9.0
 
 dnl ====================================================================
 dnl Dependency Checks
@@ -115,32 +114,6 @@ if test "x$with_systemd" != "xno" ; then
 fi
 AM_CONDITIONAL(HAVE_SYSTEMD, test "x$use_systemd" = "xyes")
 AC_SUBST(HAVE_SYSTEMD)
-
-dnl ====================================================================
-dnl UPOWER
-dnl ====================================================================
-
-AC_ARG_ENABLE(upower,
-              AS_HELP_STRING([--enable-upower],
-              [Use upower to suspend/hibernate]),
-              enable_upower=$enableval,
-              enable_upower=no)
-if test "x$enable_upower" = "xyes"; then
-    PKG_CHECK_MODULES([UPOWER], [upower-glib >= $UPOWER_REQUIRED], has_upower=yes, has_upower=no)
-
-    if test "x$has_upower" = "xyes"; then
-        AC_DEFINE(HAVE_UPOWER, 1, [upower support])
-        AC_SUBST(UPOWER_CFLAGS)
-        AC_SUBST(UPOWER_LIBS)
-    fi
-    PKG_CHECK_MODULES([UPOWER_HIBERNATE], [upower-glib < 0.99], has_upower_hibernate_suspend=yes, has_upower_hibernate_suspend=no)
-    if test "x$has_upower_hibernate_suspend" = "xyes"; then
-        AC_DEFINE(HAVE_UPOWER_HIBERNATE_SUSPEND, 1, [upower based support for hibernate and suspend (< 0.99)])
-    fi
-
-fi
-AM_CONDITIONAL(HAVE_UPOWER, test "x$has_upower" = "xyes")
-AC_SUBST(HAVE_UPOWER)
 
 dnl ====================================================================
 dnl Check for XSync extension

--- a/mate-session/Makefile.am
+++ b/mate-session/Makefile.am
@@ -7,7 +7,6 @@ noinst_PROGRAMS = 		\
 AM_CPPFLAGS =					\
 	$(MATE_SESSION_CFLAGS)		\
 	$(SYSTEMD_CFLAGS)			\
-	$(UPOWER_CFLAGS)			\
 	$(DISABLE_DEPRECATED_CFLAGS)
 
 AM_CFLAGS = $(WARN_CFLAGS)
@@ -81,7 +80,6 @@ mate_session_LDADD =				\
 	$(XEXT_LIBS)				\
 	$(MATE_SESSION_LIBS)			\
 	$(SYSTEMD_LIBS)				\
-	$(UPOWER_LIBS)				\
 	$(EXECINFO_LIBS)
 
 libgsmutil_la_SOURCES =				\

--- a/mate-session/gsm-consolekit.c
+++ b/mate-session/gsm-consolekit.c
@@ -480,6 +480,65 @@ gsm_consolekit_attempt_stop (GsmConsolekit *manager)
         }
 }
 
+void
+gsm_consolekit_attempt_suspend (GsmConsolekit *manager)
+{
+        gboolean res;
+        GError  *error;
+
+        error = NULL;
+
+        if (!gsm_consolekit_ensure_ck_connection (manager, &error)) {
+                g_warning ("Could not connect to ConsoleKit: %s",
+                           error->message);
+                g_error_free (error);
+                return;
+        }
+
+        res = dbus_g_proxy_call_with_timeout (manager->priv->ck_proxy,
+                                              "Suspend",
+                                              INT_MAX,
+                                              &error,
+                                              G_TYPE_BOOLEAN, TRUE, /* interactive */
+                                              G_TYPE_INVALID,
+                                              G_TYPE_INVALID);
+
+        if (!res) {
+                g_warning ("Unable to suspend system: %s", error->message);
+                g_error_free (error);
+        }
+}
+
+void
+gsm_consolekit_attempt_hibernate (GsmConsolekit *manager)
+{
+        gboolean res;
+        GError  *error;
+
+        error = NULL;
+
+        if (!gsm_consolekit_ensure_ck_connection (manager, &error)) {
+                g_warning ("Could not connect to ConsoleKit: %s",
+                           error->message);
+                g_error_free (error);
+                return;
+        }
+
+        res = dbus_g_proxy_call_with_timeout (manager->priv->ck_proxy,
+                                              "Hibernate",
+                                              INT_MAX,
+                                              &error,
+                                              G_TYPE_BOOLEAN, TRUE, /* interactive */
+                                              G_TYPE_INVALID,
+                                              G_TYPE_INVALID);
+
+
+        if (!res) {
+                g_warning ("Unable to hibernate system: %s", error->message);
+                g_error_free (error);
+        }
+}
+
 static gboolean
 get_current_session_id (DBusConnection *connection,
                         char          **session_id)
@@ -834,6 +893,80 @@ gsm_consolekit_can_stop (GsmConsolekit *manager)
 	}
 
 	return can_stop;
+}
+
+gboolean
+gsm_consolekit_can_suspend (GsmConsolekit *manager)
+{
+        gboolean res;
+        gboolean can_suspend;
+        gchar *retval;
+        GError *error = NULL;
+
+        if (!gsm_consolekit_ensure_ck_connection (manager, &error)) {
+                g_warning ("Could not connect to ConsoleKit: %s",
+                           error->message);
+                g_error_free (error);
+                return FALSE;
+        }
+
+        res = dbus_g_proxy_call_with_timeout (manager->priv->ck_proxy,
+                                              "CanSuspend",
+                                              INT_MAX,
+                                              &error,
+                                              G_TYPE_INVALID,
+                                              G_TYPE_STRING, &retval,
+                                              G_TYPE_INVALID);
+
+        if (res == FALSE) {
+                g_warning ("Could not make DBUS call: %s",
+                           error->message);
+                g_error_free (error);
+                return FALSE;
+        }
+
+        can_suspend = g_strcmp0 (retval, "yes") == 0 ||
+                      g_strcmp0 (retval, "challenge") == 0;
+
+        g_free (retval);
+        return can_suspend;
+}
+
+gboolean
+gsm_consolekit_can_hibernate (GsmConsolekit *manager)
+{
+        gboolean res;
+        gboolean can_hibernate;
+        gchar *retval;
+        GError *error = NULL;
+
+        if (!gsm_consolekit_ensure_ck_connection (manager, &error)) {
+                g_warning ("Could not connect to ConsoleKit: %s",
+                           error->message);
+                g_error_free (error);
+                return FALSE;
+        }
+
+        res = dbus_g_proxy_call_with_timeout (manager->priv->ck_proxy,
+                                              "CanHibernate",
+                                              INT_MAX,
+                                              &error,
+                                              G_TYPE_INVALID,
+                                              G_TYPE_STRING, &retval,
+                                              G_TYPE_INVALID);
+
+        if (res == FALSE) {
+                g_warning ("Could not make DBUS call: %s",
+                           error->message);
+                g_error_free (error);
+                return FALSE;
+        }
+
+        can_hibernate = g_strcmp0 (retval, "yes") == 0 ||
+                        g_strcmp0 (retval, "challenge") == 0;
+
+        g_free (retval);
+        return can_hibernate;
 }
 
 gchar *

--- a/mate-session/gsm-consolekit.h
+++ b/mate-session/gsm-consolekit.h
@@ -87,9 +87,17 @@ gboolean         gsm_consolekit_can_stop        (GsmConsolekit *manager);
 
 gboolean         gsm_consolekit_can_restart     (GsmConsolekit *manager);
 
+gboolean         gsm_consolekit_can_suspend     (GsmConsolekit *manager);
+
+gboolean         gsm_consolekit_can_hibernate   (GsmConsolekit *manager);
+
 void             gsm_consolekit_attempt_stop    (GsmConsolekit *manager);
 
 void             gsm_consolekit_attempt_restart (GsmConsolekit *manager);
+
+void             gsm_consolekit_attempt_suspend (GsmConsolekit *manager);
+
+void             gsm_consolekit_attempt_hibernate (GsmConsolekit *manager);
 
 void             gsm_consolekit_set_session_idle (GsmConsolekit *manager,
                                                   gboolean       is_idle);

--- a/mate-session/gsm-logout-dialog.c
+++ b/mate-session/gsm-logout-dialog.c
@@ -27,10 +27,6 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
-#ifdef HAVE_UPOWER
-#include <upower.h>
-#endif
-
 #include "gsm-logout-dialog.h"
 #ifdef HAVE_SYSTEMD
 #include "gsm-systemd.h"
@@ -58,9 +54,6 @@ typedef enum {
 struct _GsmLogoutDialogPrivate
 {
         GsmDialogLogoutType  type;
-#ifdef HAVE_UPOWER
-        UpClient            *up_client;
-#endif
 #ifdef HAVE_SYSTEMD
         GsmSystemd          *systemd;
 #endif
@@ -156,9 +149,6 @@ gsm_logout_dialog_init (GsmLogoutDialog *logout_dialog)
         gtk_window_set_skip_taskbar_hint (GTK_WINDOW (logout_dialog), TRUE);
         gtk_window_set_keep_above (GTK_WINDOW (logout_dialog), TRUE);
         gtk_window_stick (GTK_WINDOW (logout_dialog));
-#ifdef HAVE_UPOWER
-        logout_dialog->priv->up_client = up_client_new ();
-#endif
 #ifdef HAVE_SYSTEMD
         if (LOGIND_RUNNING())
             logout_dialog->priv->systemd = gsm_get_systemd ();
@@ -185,12 +175,6 @@ gsm_logout_dialog_destroy (GsmLogoutDialog *logout_dialog,
                 g_source_remove (logout_dialog->priv->timeout_id);
                 logout_dialog->priv->timeout_id = 0;
         }
-#ifdef HAVE_UPOWER
-        if (logout_dialog->priv->up_client) {
-                g_object_unref (logout_dialog->priv->up_client);
-                logout_dialog->priv->up_client = NULL;
-        }
-#endif
 #ifdef HAVE_SYSTEMD
         if (logout_dialog->priv->systemd) {
                 g_object_unref (logout_dialog->priv->systemd);
@@ -214,12 +198,8 @@ gsm_logout_supports_system_suspend (GsmLogoutDialog *logout_dialog)
 #ifdef HAVE_SYSTEMD
         if (LOGIND_RUNNING())
             ret = gsm_systemd_can_suspend (logout_dialog->priv->systemd);
-#endif
-#if defined(HAVE_SYSTEMD) && defined(HAVE_UPOWER_HIBERNATE_SUSPEND)
-        else
-#endif
-#ifdef HAVE_UPOWER_HIBERNATE_SUSPEND
-        ret = up_client_get_can_suspend (logout_dialog->priv->up_client);
+#else
+	ret = gsm_consolekit_can_suspend (logout_dialog->priv->consolekit);
 #endif
         return ret;
 }
@@ -232,12 +212,8 @@ gsm_logout_supports_system_hibernate (GsmLogoutDialog *logout_dialog)
 #ifdef HAVE_SYSTEMD
         if (LOGIND_RUNNING())
             ret = gsm_systemd_can_hibernate (logout_dialog->priv->systemd);
-#endif
-#if defined(HAVE_SYSTEMD) && defined(HAVE_UPOWER_HIBERNATE_SUSPEND)
-        else
-#endif
-#ifdef HAVE_UPOWER_HIBERNATE_SUSPEND
-        ret = up_client_get_can_hibernate (logout_dialog->priv->up_client);
+#else
+        ret = gsm_consolekit_can_hibernate (logout_dialog->priv->consolekit);
 #endif
         return ret;
 }


### PR DESCRIPTION
Forward port of Infrit's CK2 patch 
This requires ConsoleKit2 version 0.9.2.