### PR TITLE
don't lose focus when displaying logout or shutdown dialog

### DIFF
--- a/mate-session/gsm-manager.c
+++ b/mate-session/gsm-manager.c
@@ -40,6 +40,7 @@
 
 #include <gtk/gtk.h> /* for logout dialog */
 #include <gio/gio.h> /* for gsettings */
+#include <gdk/gdkx.h>
 
 #include "gsm-manager.h"
 #include "gsm-manager-glue.h"
@@ -3185,6 +3186,8 @@ show_shutdown_dialog (GsmManager *manager)
                           G_CALLBACK (logout_dialog_response),
                           manager);
         gtk_widget_show (dialog);
+        gtk_window_present_with_time (GTK_WINDOW (dialog),
+                                      gdk_x11_get_server_time (gtk_widget_get_window (GTK_WIDGET (dialog))));
 }
 
 static void
@@ -3207,6 +3210,8 @@ show_logout_dialog (GsmManager *manager)
                           G_CALLBACK (logout_dialog_response),
                           manager);
         gtk_widget_show (dialog);
+        gtk_window_present_with_time (GTK_WINDOW (dialog),
+                                      gdk_x11_get_server_time (gtk_widget_get_window (GTK_WIDGET (dialog))));
 }
 
 static void


### PR DESCRIPTION
same as done in:
https://github.com/mate-desktop/mate-polkit/commit/ed37b52fbfbce5d57d0549fac1a9dca2502f3372

fixes https://github.com/mate-desktop/mate-session-manager/issues/123
fixes https://github.com/mate-desktop/mate-session-manager/issues/140