### PR TITLE
Backport restart user bus

### DIFF
--- a/mate-session/gsm-manager.c
+++ b/mate-session/gsm-manager.c
@@ -147,6 +147,7 @@ struct GsmManagerPrivate
 
         DBusGProxy             *bus_proxy;
         DBusGConnection        *connection;
+        gboolean                dbus_disconnected : 1;
 };
 
 enum {
@@ -1719,6 +1720,11 @@ _disconnect_client (GsmManager *manager,
                                                      "phase");
         }
 
+        if (manager->priv->dbus_disconnected && GSM_IS_DBUS_CLIENT (client)) {
+                g_debug ("GsmManager: dbus disconnected, not restarting application");
+                goto out;
+        }
+
         if (app == NULL) {
                 g_debug ("GsmManager: unable to find application for client - not restarting");
                 goto out;
@@ -1773,6 +1779,12 @@ _disconnect_dbus_client (const char       *id,
                 return FALSE;
         }
 
+        /* If no service name, then we simply disconnect all clients */
+        if (!data->service_name) {
+                _disconnect_client (data->manager, client);
+                return TRUE;
+        }
+
         name = gsm_dbus_client_get_bus_name (GSM_DBUS_CLIENT (client));
         if (IS_STRING_EMPTY (name)) {
                 return FALSE;
@@ -1786,6 +1798,15 @@ _disconnect_dbus_client (const char       *id,
         return FALSE;
 }
 
+/**
+ * remove_clients_for_connection:
+ * @manager: a #GsmManager
+ * @service_name: a service name
+ *
+ * Disconnects clients that own @service_name.
+ *
+ * If @service_name is NULL, then disconnects all clients for the connection.
+ */
 static void
 remove_clients_for_connection (GsmManager *manager,
                                const char *service_name)
@@ -1869,10 +1890,32 @@ bus_name_owner_changed (DBusGProxy  *bus_proxy,
         }
 }
 
+static DBusHandlerResult
+gsm_manager_bus_filter (DBusConnection *connection,
+                        DBusMessage    *message,
+                        void           *user_data)
+{
+        GsmManager *manager;
+
+        manager = GSM_MANAGER (user_data);
+
+        if (dbus_message_is_signal (message,
+                                    DBUS_INTERFACE_LOCAL, "Disconnected") &&
+            strcmp (dbus_message_get_path (message), DBUS_PATH_LOCAL) == 0) {
+                g_debug ("GsmManager: dbus disconnected; disconnecting dbus clients...");
+                manager->priv->dbus_disconnected = TRUE;
+                remove_clients_for_connection (manager, NULL);
+                /* let other filters get this disconnected signal, so that they
+                 * can handle it too */
+        }
+
+        return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+}
 static gboolean
 register_manager (GsmManager *manager)
 {
         GError *error = NULL;
+        DBusConnection *connection;
 
         error = NULL;
         manager->priv->connection = dbus_g_bus_get (DBUS_BUS_SESSION, &error);
@@ -1883,6 +1926,12 @@ register_manager (GsmManager *manager)
                 }
                 exit (1);
         }
+
+        connection = dbus_g_connection_get_connection (manager->priv->connection);
+        dbus_connection_add_filter (connection,
+                                    gsm_manager_bus_filter,
+                                    manager, NULL);
+        manager->priv->dbus_disconnected = FALSE;
 
         manager->priv->bus_proxy = dbus_g_proxy_new_for_name (manager->priv->connection,
                                                               DBUS_SERVICE_DBUS,

--- a/mate-session/gsm-manager.c
+++ b/mate-session/gsm-manager.c
@@ -595,15 +595,6 @@ app_registered (GsmApp     *app,
 }
 
 static gboolean
-_client_failed_to_stop (const char *id,
-                        GsmClient  *client,
-                        gpointer    user_data)
-{
-        g_debug ("GsmManager: client failed to stop: %s, %s", gsm_client_peek_id (client), gsm_client_peek_app_id (client));
-        return FALSE;
-}
-
-static gboolean
 on_phase_timeout (GsmManager *manager)
 {
         GSList *a;
@@ -630,9 +621,6 @@ on_phase_timeout (GsmManager *manager)
         case GSM_MANAGER_PHASE_END_SESSION:
                 break;
         case GSM_MANAGER_PHASE_EXIT:
-                gsm_store_foreach (manager->priv->clients,
-                                   (GsmStoreFunc)_client_failed_to_stop,
-                                   NULL);
                 break;
         default:
                 g_assert_not_reached ();
@@ -874,16 +862,12 @@ static void
 do_phase_exit (GsmManager *manager)
 {
         if (gsm_store_size (manager->priv->clients) > 0) {
-                manager->priv->phase_timeout_id = g_timeout_add_seconds (GSM_MANAGER_EXIT_PHASE_TIMEOUT,
-                                                                         (GSourceFunc)on_phase_timeout,
-                                                                         manager);
-
                 gsm_store_foreach (manager->priv->clients,
                                    (GsmStoreFunc)_client_stop,
                                    NULL);
-        } else {
-                end_phase (manager);
         }
+
+        end_phase (manager);
 }
 
 static gboolean

--- a/mate-session/gsm-systemd.c
+++ b/mate-session/gsm-systemd.c
@@ -416,6 +416,68 @@ emit_stop_complete (GsmSystemd *manager,
     }
 }
 
+gboolean
+gsm_systemd_is_last_session_for_user (GsmSystemd *manager)
+{
+        char **sessions = NULL;
+        char *session = NULL;
+        gboolean is_last_session;
+        int ret, i;
+
+        ret = sd_pid_get_session (getpid (), &session);
+
+        if (ret != 0) {
+                return FALSE;
+        }
+
+        ret = sd_uid_get_sessions (getuid (), FALSE, &sessions);
+
+        if (ret <= 0) {
+                free (session);
+                return FALSE;
+        }
+
+        is_last_session = TRUE;
+        for (i = 0; sessions[i]; i++) {
+                char *state = NULL;
+                char *type = NULL;
+
+                if (g_strcmp0 (sessions[i], session) == 0)
+                        continue;
+
+                ret = sd_session_get_state (sessions[i], &state);
+
+                if (ret != 0)
+                        continue;
+
+                if (g_strcmp0 (state, "closing") == 0) {
+                        free (state);
+                        continue;
+                }
+                free (state);
+
+                ret = sd_session_get_type (sessions[i], &type);
+
+                if (ret != 0)
+                        continue;
+
+                if (g_strcmp0 (type, "x11") != 0 &&
+                    g_strcmp0 (type, "wayland") != 0) {
+                        free (type);
+                        continue;
+                }
+
+                is_last_session = FALSE;
+        }
+
+        for (i = 0; sessions[i]; i++)
+                free (sessions[i]);
+        free (sessions);
+        free (session);
+
+        return is_last_session;
+}
+
 void
 gsm_systemd_attempt_restart (GsmSystemd *manager)
 {

--- a/mate-session/gsm-systemd.h
+++ b/mate-session/gsm-systemd.h
@@ -93,6 +93,8 @@ gboolean         gsm_systemd_can_hibernate     (GsmSystemd *manager);
 
 gboolean         gsm_systemd_can_suspend     (GsmSystemd *manager);
 
+gboolean         gsm_systemd_is_last_session_for_user (GsmSystemd *manager);
+
 void             gsm_systemd_attempt_stop    (GsmSystemd *manager);
 
 void             gsm_systemd_attempt_restart (GsmSystemd *manager);


### PR DESCRIPTION
This change should attempt to restart the user bus when the user logs out of their last graphical session. That way all processes associated with the session should terminate. I found it a bit erratic to reproduce #165 reliably, but I have seen the issue, and since running this branch I haven't encountered the issue, but I find it hard to guarantee that it will always work, so please test as much as you can.

Fixes #165 
