### PR TITLE
session-properties.ui: avoid deprecated GtkImage:stock

### DIFF
--- a/data/session-properties.ui
+++ b/data/session-properties.ui
@@ -82,7 +82,7 @@
                 <property name="layout_style">start</property>
                 <child>
                   <object class="GtkButton" id="session_properties_add_button">
-                    <property name="label">_Add</property>
+                    <property name="label" translatable="yes">_Add</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
@@ -97,7 +97,7 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="session_properties_delete_button">
-                    <property name="label">_Remove</property>
+                    <property name="label" translatable="yes">_Remove</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
@@ -113,7 +113,7 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="session_properties_edit_button">
-                    <property name="label">_Edit</property>
+                    <property name="label" translatable="yes">_Edit</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
@@ -192,7 +192,7 @@
                       <object class="GtkImage" id="image1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="stock">gtk-save</property>
+                        <property name="icon_name">document-save</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>


### PR DESCRIPTION
In this commit I added the property `translatable=yes` to the buttons, and I fixed the deprecated GtkImage:stock