### PR TITLE
Add a delay setting to Startup Manager

### DIFF
--- a/capplet/gsm-app-dialog.c
+++ b/capplet/gsm-app-dialog.c
@@ -33,6 +33,7 @@
 #define CAPPLET_NAME_ENTRY_WIDGET_NAME    "session_properties_name_entry"
 #define CAPPLET_COMMAND_ENTRY_WIDGET_NAME "session_properties_command_entry"
 #define CAPPLET_COMMENT_ENTRY_WIDGET_NAME "session_properties_comment_entry"
+#define CAPPLET_DELAY_SPIN_WIDGET_NAME    "session_properties_delay_spin"
 #define CAPPLET_BROWSE_WIDGET_NAME        "session_properties_browse_button"
 
 #ifdef __GNUC__
@@ -47,10 +48,12 @@ struct _GsmAppDialog
         GtkWidget *name_entry;
         GtkWidget *command_entry;
         GtkWidget *comment_entry;
+        GtkWidget *delay_spin;
         GtkWidget *browse_button;
         char      *name;
         char      *command;
         char      *comment;
+        guint      delay;
 };
 
 static void     gsm_app_dialog_class_init  (GsmAppDialogClass *klass);
@@ -60,7 +63,8 @@ enum {
         PROP_0,
         PROP_NAME,
         PROP_COMMAND,
-        PROP_COMMENT
+        PROP_COMMENT,
+        PROP_DELAY
 };
 
 G_DEFINE_TYPE (GsmAppDialog, gsm_app_dialog, GTK_TYPE_DIALOG)
@@ -151,6 +155,24 @@ on_entry_activate (GtkEntry     *entry,
         gtk_dialog_response (GTK_DIALOG (dialog), GTK_RESPONSE_OK);
 }
 
+static gboolean
+on_spin_output (GtkSpinButton *spin, GsmAppDialog *dialog)
+{
+        GtkAdjustment *adjustment;
+        gchar *text;
+        int value;
+
+        adjustment = gtk_spin_button_get_adjustment (spin);
+        value = gtk_adjustment_get_value (adjustment);
+        dialog->delay = value;
+
+        text = g_strdup_printf (_("%d s"), value);
+        gtk_entry_set_text (GTK_ENTRY (spin), text);
+        g_free (text);
+
+        return TRUE;
+}
+
 static void
 setup_dialog (GsmAppDialog *dialog)
 {
@@ -234,6 +256,17 @@ setup_dialog (GsmAppDialog *dialog)
                 gtk_entry_set_text (GTK_ENTRY (dialog->comment_entry), dialog->comment);
         }
 
+        dialog->delay_spin = GTK_WIDGET(gtk_builder_get_object (xml, CAPPLET_DELAY_SPIN_WIDGET_NAME));
+        g_signal_connect (dialog->delay_spin,
+                          "output",
+                          G_CALLBACK (on_spin_output),
+                          dialog);
+        if (dialog->delay > 0) {
+                GtkAdjustment *adjustment;
+                adjustment = gtk_spin_button_get_adjustment (GTK_SPIN_BUTTON(dialog->delay_spin));
+                gtk_adjustment_set_value (adjustment, (gdouble) dialog->delay);
+        }
+
         if (xml != NULL) {
                 g_object_unref (xml);
         }
@@ -311,6 +344,16 @@ gsm_app_dialog_set_comment (GsmAppDialog *dialog,
         g_object_notify (G_OBJECT (dialog), "comment");
 }
 
+static void
+gsm_app_dialog_set_delay (GsmAppDialog *dialog,
+                          guint delay)
+{
+        g_return_if_fail (GSM_IS_APP_DIALOG (dialog));
+
+        dialog->delay = delay;
+        g_object_notify (G_OBJECT (dialog), "delay");
+}
+
 const char *
 gsm_app_dialog_get_name (GsmAppDialog *dialog)
 {
@@ -332,6 +375,13 @@ gsm_app_dialog_get_comment (GsmAppDialog *dialog)
         return gtk_entry_get_text (GTK_ENTRY (dialog->comment_entry));
 }
 
+guint
+gsm_app_dialog_get_delay (GsmAppDialog *dialog)
+{
+        g_return_val_if_fail (GSM_IS_APP_DIALOG (dialog), 0);
+        return dialog->delay;
+}
+
 static void
 gsm_app_dialog_set_property (GObject        *object,
                              guint           prop_id,
@@ -349,6 +399,9 @@ gsm_app_dialog_set_property (GObject        *object,
                 break;
         case PROP_COMMENT:
                 gsm_app_dialog_set_comment (dialog, g_value_get_string (value));
+                break;
+        case PROP_DELAY:
+                gsm_app_dialog_set_delay (dialog, g_value_get_uint (value));
                 break;
         default:
                 G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -373,6 +426,9 @@ gsm_app_dialog_get_property (GObject        *object,
                 break;
         case PROP_COMMENT:
                 g_value_set_string (value, dialog->comment);
+                break;
+        case PROP_DELAY:
+                g_value_set_uint (value, dialog->delay);
                 break;
         default:
                 G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -411,6 +467,15 @@ gsm_app_dialog_class_init (GsmAppDialogClass *klass)
                                                               "comment",
                                                               NULL,
                                                               G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+        g_object_class_install_property (object_class,
+                                         PROP_DELAY,
+                                         g_param_spec_uint ("delay",
+                                                            "delay",
+                                                            "delay",
+                                                             0,
+                                                             100,
+                                                             0,
+                                                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
 }
 
 static void
@@ -422,7 +487,8 @@ gsm_app_dialog_init (GsmAppDialog *dialog)
 GtkWidget *
 gsm_app_dialog_new (const char *name,
                     const char *command,
-                    const char *comment)
+                    const char *comment,
+                    guint delay)
 {
         GObject *object;
 
@@ -430,6 +496,7 @@ gsm_app_dialog_new (const char *name,
                                "name", name,
                                "command", command,
                                "comment", comment,
+                               "delay", delay,
                                NULL);
 
         return GTK_WIDGET (object);
@@ -439,7 +506,8 @@ gboolean
 gsm_app_dialog_run (GsmAppDialog  *dialog,
                     char         **name_p,
                     char         **command_p,
-                    char         **comment_p)
+                    char         **comment_p,
+                    guint         *delay_p)
 {
         gboolean retval;
 
@@ -449,6 +517,7 @@ gsm_app_dialog_run (GsmAppDialog  *dialog,
                 const char *name;
                 const char *exec;
                 const char *comment;
+                guint       delay;
                 const char *error_msg;
                 GError     *error;
                 char      **argv;
@@ -457,6 +526,7 @@ gsm_app_dialog_run (GsmAppDialog  *dialog,
                 name = gsm_app_dialog_get_name (GSM_APP_DIALOG (dialog));
                 exec = gsm_app_dialog_get_command (GSM_APP_DIALOG (dialog));
                 comment = gsm_app_dialog_get_comment (GSM_APP_DIALOG (dialog));
+                delay = gsm_app_dialog_get_delay (GSM_APP_DIALOG (dialog));
 
                 error = NULL;
                 error_msg = NULL;
@@ -509,6 +579,10 @@ gsm_app_dialog_run (GsmAppDialog  *dialog,
 
                 if (comment_p) {
                         *comment_p = g_strdup (comment);
+                }
+
+                if (delay_p) {
+                        *delay_p = delay;
                 }
 
                 retval = TRUE;

--- a/capplet/gsm-app-dialog.h
+++ b/capplet/gsm-app-dialog.h
@@ -31,16 +31,19 @@ G_DECLARE_FINAL_TYPE (GsmAppDialog, gsm_app_dialog, GSM, APP_DIALOG, GtkDialog)
 
 GtkWidget            * gsm_app_dialog_new                (const char   *name,
                                                           const char   *command,
-                                                          const char   *comment);
+                                                          const char   *comment,
+                                                          guint         delay);
 
 gboolean               gsm_app_dialog_run               (GsmAppDialog  *dialog,
                                                          char         **name_p,
                                                          char         **command_p,
-                                                         char         **comment_p);
+                                                         char         **comment_p,
+                                                         guint         *delay);
 
 const char *           gsm_app_dialog_get_name           (GsmAppDialog *dialog);
 const char *           gsm_app_dialog_get_command        (GsmAppDialog *dialog);
 const char *           gsm_app_dialog_get_comment        (GsmAppDialog *dialog);
+guint                  gsm_app_dialog_get_delay          (GsmAppDialog *dialog);
 
 G_END_DECLS
 

--- a/capplet/gsm-properties-dialog.c
+++ b/capplet/gsm-properties-dialog.c
@@ -361,14 +361,15 @@ on_add_app_clicked (GtkWidget           *widget,
         char       *name;
         char       *exec;
         char       *comment;
+        guint       delay;
 
-        add_dialog = gsm_app_dialog_new (NULL, NULL, NULL);
+        add_dialog = gsm_app_dialog_new (NULL, NULL, NULL, 0);
         gtk_window_set_transient_for (GTK_WINDOW (add_dialog),
                                       GTK_WINDOW (dialog));
 
         if (gsm_app_dialog_run (GSM_APP_DIALOG (add_dialog),
-                                &name, &exec, &comment)) {
-                gsp_app_create (name, comment, exec);
+                                &name, &exec, &comment, &delay)) {
+                gsp_app_create (name, comment, exec, delay);
                 g_free (name);
                 g_free (exec);
                 g_free (comment);
@@ -426,16 +427,18 @@ on_edit_app_clicked (GtkWidget           *widget,
                 char       *name;
                 char       *exec;
                 char       *comment;
+                guint       delay;
 
                 edit_dialog = gsm_app_dialog_new (gsp_app_get_name (app),
                                                   gsp_app_get_exec (app),
-                                                  gsp_app_get_comment (app));
+                                                  gsp_app_get_comment (app),
+                                                  gsp_app_get_delay (app));
                 gtk_window_set_transient_for (GTK_WINDOW (edit_dialog),
                                               GTK_WINDOW (dialog));
 
                 if (gsm_app_dialog_run (GSM_APP_DIALOG (edit_dialog),
-                                        &name, &exec, &comment)) {
-                        gsp_app_update (app, name, comment, exec);
+                                        &name, &exec, &comment, &delay)) {
+                        gsp_app_update (app, name, comment, exec, delay);
                         g_free (name);
                         g_free (exec);
                         g_free (comment);

--- a/capplet/gsp-app.c
+++ b/capplet/gsp-app.c
@@ -320,6 +320,7 @@ _gsp_app_user_equal_system (GspApp  *app,
         char          *path;
         char          *str;
         GKeyFile      *keyfile;
+        guint          delay;
 
         manager = gsp_app_manager_get ();
         priv = gsp_app_get_instance_private (app);
@@ -389,6 +390,13 @@ _gsp_app_user_equal_system (GspApp  *app,
                 return FALSE;
         }
         g_free (str);
+
+        delay = gsp_key_file_get_delay(keyfile);
+        if (delay != priv->delay) {
+                g_free (path);
+                g_key_file_free (keyfile);
+                return FALSE;
+        }
 
         g_key_file_free (keyfile);
 

--- a/capplet/gsp-app.h
+++ b/capplet/gsp-app.h
@@ -44,11 +44,13 @@ GType            gsp_app_get_type          (void) G_GNUC_CONST;
 
 void             gsp_app_create            (const char   *name,
                                             const char   *comment,
-                                            const char   *exec);
+                                            const char   *exec,
+                                            guint         delay);
 void             gsp_app_update            (GspApp       *app,
                                             const char   *name,
                                             const char   *comment,
-                                            const char   *exec);
+                                            const char   *exec,
+                                            guint         delay);
 
 gboolean         gsp_app_copy_desktop_file (const char   *uri);
 
@@ -66,6 +68,7 @@ void             gsp_app_set_enabled       (GspApp       *app,
 const char      *gsp_app_get_name          (GspApp       *app);
 const char      *gsp_app_get_exec          (GspApp       *app);
 const char      *gsp_app_get_comment       (GspApp       *app);
+guint            gsp_app_get_delay         (GspApp       *app);
 
 const char      *gsp_app_get_description   (GspApp       *app);
 GIcon           *gsp_app_get_icon          (GspApp       *app);

--- a/capplet/gsp-keyfile.h
+++ b/capplet/gsp-keyfile.h
@@ -34,6 +34,8 @@ extern "C" {
 #endif
 
 #define GSP_KEY_FILE_DESKTOP_KEY_AUTOSTART_ENABLED "X-MATE-Autostart-enabled"
+#define GSP_KEY_FILE_DESKTOP_KEY_GNOME_DELAY       "X-GNOME-Autostart-Delay"
+#define GSP_KEY_FILE_DESKTOP_KEY_DELAY             "X-MATE-Autostart-Delay"
 
 void      gsp_key_file_populate        (GKeyFile *keyfile);
 
@@ -46,6 +48,9 @@ gboolean gsp_key_file_get_boolean      (GKeyFile       *keyfile,
                                         gboolean        default_value);
 #define gsp_key_file_get_string(key_file, key) \
          g_key_file_get_string (key_file, G_KEY_FILE_DESKTOP_GROUP, key, NULL)
+#define gsp_key_file_get_delay(key_file) \
+         (g_key_file_get_integer (key_file, G_KEY_FILE_DESKTOP_GROUP, GSP_KEY_FILE_DESKTOP_KEY_GNOME_DELAY, NULL) + \
+         g_key_file_get_integer (key_file, G_KEY_FILE_DESKTOP_GROUP, GSP_KEY_FILE_DESKTOP_KEY_DELAY, NULL))
 #define gsp_key_file_get_locale_string(key_file, key) \
          g_key_file_get_locale_string(key_file, G_KEY_FILE_DESKTOP_GROUP, key, NULL, NULL)
 
@@ -53,6 +58,12 @@ gboolean gsp_key_file_get_boolean      (GKeyFile       *keyfile,
          g_key_file_set_boolean (key_file, G_KEY_FILE_DESKTOP_GROUP, key, value)
 #define gsp_key_file_set_string(key_file, key, value) \
          g_key_file_set_string (key_file, G_KEY_FILE_DESKTOP_GROUP, key, value)
+#define gsp_key_file_set_delay(key_file, value) \
+        do { \
+        if (g_key_file_has_key (key_file, G_KEY_FILE_DESKTOP_GROUP, GSP_KEY_FILE_DESKTOP_KEY_GNOME_DELAY, NULL)) \
+                g_key_file_remove_key (key_file, G_KEY_FILE_DESKTOP_GROUP, GSP_KEY_FILE_DESKTOP_KEY_GNOME_DELAY, NULL); \
+        g_key_file_set_integer(key_file, G_KEY_FILE_DESKTOP_GROUP, GSP_KEY_FILE_DESKTOP_KEY_DELAY, value); \
+        } while (0);
 void    gsp_key_file_set_locale_string (GKeyFile    *keyfile,
                                         const gchar *key,
                                         const gchar *value);

--- a/capplet/gsp-keyfile.h
+++ b/capplet/gsp-keyfile.h
@@ -34,7 +34,6 @@ extern "C" {
 #endif
 
 #define GSP_KEY_FILE_DESKTOP_KEY_AUTOSTART_ENABLED "X-MATE-Autostart-enabled"
-#define GSP_KEY_FILE_DESKTOP_KEY_GNOME_DELAY       "X-GNOME-Autostart-Delay"
 #define GSP_KEY_FILE_DESKTOP_KEY_DELAY             "X-MATE-Autostart-Delay"
 
 void      gsp_key_file_populate        (GKeyFile *keyfile);
@@ -49,8 +48,7 @@ gboolean gsp_key_file_get_boolean      (GKeyFile       *keyfile,
 #define gsp_key_file_get_string(key_file, key) \
          g_key_file_get_string (key_file, G_KEY_FILE_DESKTOP_GROUP, key, NULL)
 #define gsp_key_file_get_delay(key_file) \
-         (g_key_file_get_integer (key_file, G_KEY_FILE_DESKTOP_GROUP, GSP_KEY_FILE_DESKTOP_KEY_GNOME_DELAY, NULL) + \
-         g_key_file_get_integer (key_file, G_KEY_FILE_DESKTOP_GROUP, GSP_KEY_FILE_DESKTOP_KEY_DELAY, NULL))
+         g_key_file_get_integer (key_file, G_KEY_FILE_DESKTOP_GROUP, GSP_KEY_FILE_DESKTOP_KEY_DELAY, NULL)
 #define gsp_key_file_get_locale_string(key_file, key) \
          g_key_file_get_locale_string(key_file, G_KEY_FILE_DESKTOP_GROUP, key, NULL, NULL)
 
@@ -59,11 +57,7 @@ gboolean gsp_key_file_get_boolean      (GKeyFile       *keyfile,
 #define gsp_key_file_set_string(key_file, key, value) \
          g_key_file_set_string (key_file, G_KEY_FILE_DESKTOP_GROUP, key, value)
 #define gsp_key_file_set_delay(key_file, value) \
-        do { \
-        if (g_key_file_has_key (key_file, G_KEY_FILE_DESKTOP_GROUP, GSP_KEY_FILE_DESKTOP_KEY_GNOME_DELAY, NULL)) \
-                g_key_file_remove_key (key_file, G_KEY_FILE_DESKTOP_GROUP, GSP_KEY_FILE_DESKTOP_KEY_GNOME_DELAY, NULL); \
-        g_key_file_set_integer(key_file, G_KEY_FILE_DESKTOP_GROUP, GSP_KEY_FILE_DESKTOP_KEY_DELAY, value); \
-        } while (0);
+        g_key_file_set_integer(key_file, G_KEY_FILE_DESKTOP_GROUP, GSP_KEY_FILE_DESKTOP_KEY_DELAY, value)
 void    gsp_key_file_set_locale_string (GKeyFile    *keyfile,
                                         const gchar *key,
                                         const gchar *value);

--- a/data/session-properties.ui
+++ b/data/session-properties.ui
@@ -246,6 +246,11 @@
       </packing>
     </child>
   </object>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkGrid" id="main-table">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -350,6 +355,31 @@
       <packing>
         <property name="left_attach">0</property>
         <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label_delay">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">_Delay:</property>
+        <property name="use_underline">True</property>
+        <property name="mnemonic_widget">session_properties_delay_spin</property>
+        <property name="xalign">0</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSpinButton" id="session_properties_delay_spin">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="adjustment">adjustment1</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">3</property>
       </packing>
     </child>
   </object>


### PR DESCRIPTION
Fixed issue #127
- capplet/gsm-app-dialog.c
- capplet/gsm-app-dialog.h
- capplet/gsm-properties-dialog.c
- capplet/gsp-app.c
- capplet/gsp-app.h
- capplet/gsp-keyfile.h
- data/session-properties.ui