### PR TITLE
Backport restart user bus (second attempt)

### DIFF
--- a/mate-session/gsm-manager.c
+++ b/mate-session/gsm-manager.c
@@ -610,15 +610,6 @@ app_registered (GsmApp     *app,
 }
 
 static gboolean
-_client_failed_to_stop (const char *id,
-                        GsmClient  *client,
-                        gpointer    user_data)
-{
-        g_debug ("GsmManager: client failed to stop: %s, %s", gsm_client_peek_id (client), gsm_client_peek_app_id (client));
-        return FALSE;
-}
-
-static gboolean
 on_phase_timeout (GsmManager *manager)
 {
         GSList *a;
@@ -647,9 +638,6 @@ on_phase_timeout (GsmManager *manager)
         case GSM_MANAGER_PHASE_END_SESSION:
                 break;
         case GSM_MANAGER_PHASE_EXIT:
-                gsm_store_foreach (priv->clients,
-                                   (GsmStoreFunc)_client_failed_to_stop,
-                                   NULL);
                 break;
         default:
                 g_assert_not_reached ();
@@ -907,16 +895,12 @@ do_phase_exit (GsmManager *manager)
 
         priv = gsm_manager_get_instance_private (manager);
         if (gsm_store_size (priv->clients) > 0) {
-                priv->phase_timeout_id = g_timeout_add_seconds (GSM_MANAGER_EXIT_PHASE_TIMEOUT,
-                                                                (GSourceFunc)on_phase_timeout,
-                                                                manager);
-
                 gsm_store_foreach (priv->clients,
                                    (GsmStoreFunc)_client_stop,
                                    NULL);
-        } else {
-                end_phase (manager);
         }
+
+        end_phase (manager);
 }
 
 static gboolean

--- a/mate-session/gsm-systemd.h
+++ b/mate-session/gsm-systemd.h
@@ -76,6 +76,8 @@ gboolean         gsm_systemd_can_hibernate     (GsmSystemd *manager);
 
 gboolean         gsm_systemd_can_suspend     (GsmSystemd *manager);
 
+gboolean         gsm_systemd_is_last_session_for_user (GsmSystemd *manager);
+
 void             gsm_systemd_attempt_stop    (GsmSystemd *manager);
 
 void             gsm_systemd_attempt_restart (GsmSystemd *manager);


### PR DESCRIPTION
This finally seems to work. All process should terminate upon logout now.

How to test this:
* Log in to MATE
* Switch to a separate tty (`Ctrl+Alt+F2`)
* Run `ps aux | grep $USER` - there should be a million things
* Switch back to your graphical session (`Ctrl+Alt+F1` in Fedora, `Ctrl+Alt+F7` in Ubuntu, etc)
* Log out from MATE
* Switch back to tty
* Run `ps aux | grep $USER` - with this patch, there should not be any mate-related processes

Fixes #165 