### PR TITLE
Remove keyring from gnome-compat-startup key

### DIFF
--- a/data/org.mate.session.gschema.xml.in
+++ b/data/org.mate.session.gschema.xml.in
@@ -37,7 +37,7 @@
       <description>List of components that are required as part of the session. (Each element names a key under "/org/mate/desktop/session/required_components"). The Startup Applications preferences tool will not normally allow users to remove a required component from the session, and the session manager will automatically add the required components back to the session at login time if they do get removed.</description>
     </key>
     <key name="gnome-compat-startup" type="as">
-      <default>[ 'keyring', 'smproxy' ]</default>
+      <default>[ 'smproxy' ]</default>
       <summary>Control gnome compatibility component startup</summary>
       <description>Control which compatibility components to start.</description>
     </key>


### PR DESCRIPTION
Mate Desktop support /etc/xdg/autostart elements and gnome-keyring-daemon (GKD) add entries, which mention explicitely Mate desktop there. Thus this entry is redundant. On the other hand, this entry is responsible for a "start-all-subcomponent" of GKD, which block fine selection of components to load at startup.

I think this compat element is not needed any more.

Fix: https://github.com/mate-desktop/mate-session-manager/issues/182