### PR TITLE
[Security] Use 'g_strlcpy' instead of 'strcpy'

### DIFF
--- a/mate-session/mdm.c
+++ b/mate-session/mdm.c
@@ -266,11 +266,11 @@ static gboolean mdm_init_protocol_connection(MdmProtocolData* data)
 
 	if (g_file_test(MDM_PROTOCOL_SOCKET_PATH, G_FILE_TEST_EXISTS))
 	{
-		strcpy(addr.sun_path, MDM_PROTOCOL_SOCKET_PATH);
+		g_strlcpy (addr.sun_path, MDM_PROTOCOL_SOCKET_PATH, sizeof (addr.sun_path));
 	}
 	else if (g_file_test("/tmp/.mdm_socket", G_FILE_TEST_EXISTS))
 	{
-		strcpy(addr.sun_path, "/tmp/.mdm_socket");
+		g_strlcpy (addr.sun_path, "/tmp/.mdm_socket", sizeof (addr.sun_path));
 	}
 	else
 	{


### PR DESCRIPTION
Potential insecure memory buffer bounds restriction in call 'strcpy', 
https://mate-session-manager.mate-desktop.dev/2019-04-28-021206-6482-1@b33479091537_clang-analyzer/report-d0d699.html#EndPath
https://mate-session-manager.mate-desktop.dev/2019-04-28-021206-6482-1@b33479091537_clang-analyzer/report-6da253.html#EndPath

