### PR TITLE
Hide NoDisplay Apps in Startup Applications

### DIFF
--- a/capplet/gsm-properties-dialog.c
+++ b/capplet/gsm-properties-dialog.c
@@ -181,6 +181,10 @@ append_app (GsmPropertiesDialog *dialog,
             GspApp              *app)
 {
         GtkTreeIter   iter;
+        if (find_by_app (GTK_TREE_MODEL (dialog->list_store),
+                         &iter, app)) {
+                return;
+        }
 
         gtk_list_store_append (dialog->list_store, &iter);
         _fill_iter_from_app (dialog->list_store, &iter, app);

--- a/capplet/gsp-app-manager.c
+++ b/capplet/gsp-app-manager.c
@@ -479,7 +479,7 @@ _gsp_app_manager_fill_from_dir (GspAppManager *manager,
                 desktop_file_path = g_build_filename (xdgdir->dir, name, NULL);
                 app = gsp_app_new (desktop_file_path, xdgdir->index);
 
-                if (app != NULL && !gsp_app_get_nodisplay(app)) {
+                if (app != NULL) {
                         gsp_app_manager_add (manager, app);
                         g_object_unref (app);
                 }

--- a/capplet/gsp-app-manager.c
+++ b/capplet/gsp-app-manager.c
@@ -479,7 +479,7 @@ _gsp_app_manager_fill_from_dir (GspAppManager *manager,
                 desktop_file_path = g_build_filename (xdgdir->dir, name, NULL);
                 app = gsp_app_new (desktop_file_path, xdgdir->index);
 
-                if (app != NULL) {
+                if (app != NULL && !gsp_app_get_nodisplay(app)) {
                         gsp_app_manager_add (manager, app);
                         g_object_unref (app);
                 }

--- a/capplet/gsp-app.c
+++ b/capplet/gsp-app.c
@@ -54,6 +54,7 @@ typedef struct {
         char         *path;
 
         gboolean      hidden;
+        gboolean      nodisplay;
         gboolean      enabled;
 
         char         *name;
@@ -621,6 +622,18 @@ gsp_app_set_enabled (GspApp   *app,
         _gsp_app_emit_changed (app);
 }
 
+gboolean
+gsp_app_get_nodisplay (GspApp *app)
+{
+        GspAppPrivate *priv;
+
+        g_return_val_if_fail (GSP_IS_APP (app), FALSE);
+
+        priv = gsp_app_get_instance_private (app);
+
+        return priv->nodisplay;
+}
+
 const char *
 gsp_app_get_name (GspApp *app)
 {
@@ -953,7 +966,9 @@ gsp_app_new (const char   *path,
         priv->enabled = gsp_key_file_get_boolean (keyfile,
                                                   GSP_KEY_FILE_DESKTOP_KEY_AUTOSTART_ENABLED,
                                                   TRUE);
-
+        priv->nodisplay = gsp_key_file_get_boolean (keyfile,
+                                                    G_KEY_FILE_DESKTOP_KEY_NO_DISPLAY,
+                                                    FALSE);
         priv->name = gsp_key_file_get_locale_string (keyfile,
                                                      G_KEY_FILE_DESKTOP_KEY_NAME);
         priv->exec = gsp_key_file_get_string (keyfile,
@@ -1100,6 +1115,7 @@ gsp_app_create (const char *name,
 
         priv->hidden = FALSE;
         priv->enabled = TRUE;
+        priv->nodisplay = FALSE;
 
         if (!gsm_util_text_is_blank (name)) {
                 priv->name = g_strdup (name);

--- a/capplet/gsp-app.h
+++ b/capplet/gsp-app.h
@@ -64,6 +64,7 @@ gboolean         gsp_app_get_hidden        (GspApp       *app);
 gboolean         gsp_app_get_enabled       (GspApp       *app);
 void             gsp_app_set_enabled       (GspApp       *app,
                                             gboolean      enabled);
+gboolean         gsp_app_get_nodisplay     (GspApp       *app);
 
 const char      *gsp_app_get_name          (GspApp       *app);
 const char      *gsp_app_get_exec          (GspApp       *app);

--- a/data/org.mate.session.gschema.xml.in
+++ b/data/org.mate.session.gschema.xml.in
@@ -10,6 +10,11 @@
       <summary>Save sessions</summary>
       <description>If enabled, mate-session will save the session automatically.</description>
     </key>
+    <key name="show-hidden-apps" type="b">
+      <default>false</default>
+      <summary>Show hidden autostart applications</summary>
+      <description>If enabled, mate-session-properties will show hidden autostart applications.</description>
+    </key>
     <key name="logout-prompt" type="b">
       <default>true</default>
       <summary>Logout prompt</summary>

--- a/data/session-properties.ui
+++ b/data/session-properties.ui
@@ -141,6 +141,21 @@
             <property name="position">1</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkCheckButton" id="session_properties_show_hidden_toggle">
+            <property name="label" translatable="yes">_Show hidden</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="use_underline">True</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
       </object>
     </child>
     <child type="tab">


### PR DESCRIPTION
Autostart applications are hidden in Startup Applications when NoDisplay=true.
Fix #134.