### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([mate-session-manager], [1.23.0], [http://www.mate-desktop.org/])
+AC_INIT([mate-session-manager], [1.23.0], [https://mate-desktop.org/])
 AC_CONFIG_SRCDIR([mate-session])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.