### PR TITLE
Fix mate-session-properties vertical scaling

### DIFF
--- a/data/session-properties.ui
+++ b/data/session-properties.ui
@@ -47,6 +47,7 @@
           <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="vexpand">True</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow1">
@@ -147,6 +148,8 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">end</property>
+            <property name="vexpand">False</property>
             <property name="use_underline">True</property>
             <property name="draw_indicator">True</property>
           </object>


### PR DESCRIPTION
Fixes the issue where the program list doesn't vertically scale along with the window.
