### PR TITLE
po/Makevars: Set COPYRIGHT_HOLDER to The MATE Team

### DIFF
--- a/po/Makevars
+++ b/po/Makevars
@@ -18,7 +18,7 @@ XGETTEXT_OPTIONS = --from-code=UTF-8 --keyword=_ --keyword=N_ --keyword=C_:1c,2 
 # or entity, or to disclaim their copyright.  The empty string stands for
 # the public domain; in this case the translators are expected to disclaim
 # their copyright.
-COPYRIGHT_HOLDER = Free Software Foundation, Inc.
+COPYRIGHT_HOLDER = MATE Desktop Environment team
 
 # This tells whether or not to prepend "GNU " prefix to the package
 # name that gets inserted into the header of the $(DOMAIN).pot file.


### PR DESCRIPTION
```shell
$ diff mate-session-manager.pot.pre mate-session-manager.pot
2c2
< # Copyright (C) YEAR Free Software Foundation, Inc.
---
> # Copyright (C) YEAR MATE Desktop Environment team
11c11
< "POT-Creation-Date: 2019-08-15 21:17+0200\n"
---
> "POT-Creation-Date: 2019-08-15 21:58+0200\n"
```
https://github.com/mate-desktop/caja/blob/0c420a0360f355fa89d81cce9b7696eba99bcc5c/po/Makevars#L21
