### PR TITLE
Fix timeout with gnome-keyring 3.34

### DIFF
--- a/mate-session/msm-gnome.c
+++ b/mate-session/msm-gnome.c
@@ -48,88 +48,46 @@
 
 
 static gboolean gnome_compat_started = FALSE;
-static pid_t gnome_keyring_daemon_pid = 0;
 static Window gnome_smproxy_window = None;
 
+static void
+gnome_keyring_daemon_finished (GPid pid,
+                               gint status,
+                               gpointer user_data)
+{
+  if (WEXITSTATUS (status) != 0)
+    {
+      /* daemon failed for some reason */
+      g_printerr ("gnome-keyring-daemon failed to start correctly, "
+                  "exit code: %d\n", WEXITSTATUS (status));
+    }
+}
 
 static void
 gnome_keyring_daemon_startup (void)
 {
   GError      *error = NULL;
-  gchar       *sout;
-  gchar      **lines;
-  gsize        lineno;
-  gint         status;
-  glong        pid;
-  gchar       *end;
+  GPid         pid;
   gchar       *argv[3];
-  gchar       *p;
-  gchar       *name;
-  const gchar *value;
 
   error = NULL;
   argv[0] = GNOME_KEYRING_DAEMON;
   argv[1] = "--start";
   argv[2] = NULL;
-  g_spawn_sync (NULL, argv, NULL,
-                G_SPAWN_SEARCH_PATH,
-                NULL, NULL,
-                &sout, NULL, &status, &error);
+  g_spawn_async (NULL, argv, NULL,
+		 G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD,
+		 NULL, NULL, &pid,
+		 &error);
 
   if (error != NULL)
     {
-      g_printerr ("Failed to run gnome-keyring-daemon: %s\n",
+      g_printerr ("Failed to spawn gnome-keyring-daemon: %s\n",
                   error->message);
       g_error_free (error);
+      return;
     }
-  else
-    {
-      if (WIFEXITED (status) && WEXITSTATUS (status) == 0 && sout != NULL)
-        {
-          lines = g_strsplit (sout, "\n", 0);
 
-          for (lineno = 0; lines[lineno] != NULL; lineno++)
-            {
-              p = strchr (lines[lineno], '=');
-              if (p == NULL)
-               continue;
-
-              name = g_strndup (lines[lineno], p - lines[lineno]);
-              value = p + 1;
-
-              g_setenv (name, value, TRUE);
-
-              if (g_strcmp0 (name, "GNOME_KEYRING_PID") == 0)
-                {
-                  pid = strtol (value, &end, 10);
-                  if (end != value)
-                    gnome_keyring_daemon_pid = pid;
-                }
-
-              g_free (name);
-            }
-
-          g_strfreev (lines);
-        }
-      else
-        {
-          /* daemon failed for some reason */
-          g_printerr ("gnome-keyring-daemon failed to start correctly, "
-                      "exit code: %d\n", WEXITSTATUS (status));
-        }
-
-      g_free (sout);
-    }
-}
-
-static void
-gnome_keyring_daemon_shutdown (void)
-{
-  if (gnome_keyring_daemon_pid != 0)
-    {
-      kill (gnome_keyring_daemon_pid, SIGTERM);
-      gnome_keyring_daemon_pid = 0;
-    }
+  g_child_watch_add (pid, gnome_keyring_daemon_finished, NULL);
 }
 
 
@@ -231,9 +189,6 @@ msm_gnome_stop (void)
     return;
 
   g_debug ("MsmGnome: stopping");
-
-  /* shutdown the keyring daemon */
-  gnome_keyring_daemon_shutdown ();
 
   msm_compat_gnome_smproxy_shutdown ();
 


### PR DESCRIPTION
Launch gnome-keyring-daemon asynchronously, and remove the
GNOME_KEYRING_PID reading code.

GNOME_KEYRING_PID exposure was removed from gnome-keyring in 2014.