### PR TITLE
avoid redundant redeclarations

### DIFF
--- a/capplet/gsm-app-dialog.c
+++ b/capplet/gsm-app-dialog.c
@@ -56,9 +56,6 @@ struct _GsmAppDialog
         guint      delay;
 };
 
-static void     gsm_app_dialog_class_init  (GsmAppDialogClass *klass);
-static void     gsm_app_dialog_init        (GsmAppDialog      *app_dialog);
-
 enum {
         PROP_0,
         PROP_NAME,

--- a/capplet/gsm-properties-dialog.c
+++ b/capplet/gsm-properties-dialog.c
@@ -78,8 +78,6 @@ enum {
         NUMBER_OF_COLUMNS
 };
 
-static void     gsm_properties_dialog_class_init  (GsmPropertiesDialogClass *klass);
-static void     gsm_properties_dialog_init        (GsmPropertiesDialog      *properties_dialog);
 static void     gsm_properties_dialog_finalize    (GObject                  *object);
 
 G_DEFINE_TYPE (GsmPropertiesDialog, gsm_properties_dialog, GTK_TYPE_DIALOG)

--- a/capplet/gsp-app-manager.h
+++ b/capplet/gsp-app-manager.h
@@ -43,8 +43,6 @@ struct _GspAppManagerClass
                           GspApp        *app);
 };
 
-GType           gsp_app_manager_get_type               (void) G_GNUC_CONST;
-
 GspAppManager  *gsp_app_manager_get                    (void);
 
 void            gsp_app_manager_fill                   (GspAppManager *manager);

--- a/capplet/gsp-app.h
+++ b/capplet/gsp-app.h
@@ -40,8 +40,6 @@ struct _GspAppClass
         void (* removed) (GspApp *app);
 };
 
-GType            gsp_app_get_type          (void) G_GNUC_CONST;
-
 void             gsp_app_create            (const char   *name,
                                             const char   *comment,
                                             const char   *exec,

--- a/egg/eggsmclient.h
+++ b/egg/eggsmclient.h
@@ -71,8 +71,6 @@ struct _EggSMClientClass
   void (*_egg_reserved4) (void);
 };
 
-GType            egg_sm_client_get_type            (void) G_GNUC_CONST;
-
 GOptionGroup    *egg_sm_client_get_option_group    (void);
 
 /* Initialization */

--- a/mate-session/gs-idle-monitor.c
+++ b/mate-session/gs-idle-monitor.c
@@ -39,8 +39,6 @@
 
 #include "gs-idle-monitor.h"
 
-static void gs_idle_monitor_class_init (GSIdleMonitorClass *klass);
-static void gs_idle_monitor_init       (GSIdleMonitor      *idle_monitor);
 static void gs_idle_monitor_finalize   (GObject             *object);
 
 struct _GSIdleMonitor {

--- a/mate-session/gs-idle-monitor.h
+++ b/mate-session/gs-idle-monitor.h
@@ -35,8 +35,6 @@ typedef gboolean (*GSIdleMonitorWatchFunc) (GSIdleMonitor *monitor,
                                             gboolean       condition,
                                             gpointer       user_data);
 
-GType           gs_idle_monitor_get_type       (void);
-
 GSIdleMonitor * gs_idle_monitor_new            (void);
 
 guint           gs_idle_monitor_add_watch      (GSIdleMonitor         *monitor,

--- a/mate-session/gsm-app.h
+++ b/mate-session/gsm-app.h
@@ -75,7 +75,6 @@ typedef enum
 #define GSM_APP_ERROR gsm_app_error_quark ()
 
 GQuark           gsm_app_error_quark                    (void);
-GType            gsm_app_get_type                       (void) G_GNUC_CONST;
 
 gboolean         gsm_app_peek_autorestart               (GsmApp     *app);
 

--- a/mate-session/gsm-autostart-app.h
+++ b/mate-session/gsm-autostart-app.h
@@ -40,8 +40,6 @@ struct _GsmAutostartAppClass
                                         gboolean condition);
 };
 
-GType   gsm_autostart_app_get_type           (void) G_GNUC_CONST;
-
 GsmApp *gsm_autostart_app_new                (const char *desktop_file);
 
 #define GSM_AUTOSTART_APP_ENABLED_KEY     "X-MATE-Autostart-enabled"

--- a/mate-session/gsm-client.h
+++ b/mate-session/gsm-client.h
@@ -93,7 +93,6 @@ typedef enum
 
 GType                 gsm_client_error_get_type             (void);
 GQuark                gsm_client_error_quark                (void);
-GType                 gsm_client_get_type                   (void) G_GNUC_CONST;
 
 const char           *gsm_client_peek_id                    (GsmClient  *client);
 

--- a/mate-session/gsm-consolekit.c
+++ b/mate-session/gsm-consolekit.c
@@ -64,8 +64,6 @@ enum {
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
-static void     gsm_consolekit_class_init   (GsmConsolekitClass *klass);
-static void     gsm_consolekit_init         (GsmConsolekit      *ck);
 static void     gsm_consolekit_finalize     (GObject            *object);
 
 static void     gsm_consolekit_free_dbus    (GsmConsolekit      *manager);

--- a/mate-session/gsm-consolekit.h
+++ b/mate-session/gsm-consolekit.h
@@ -56,8 +56,6 @@ enum _GsmConsolekitError {
 
 #define GSM_CONSOLEKIT_SESSION_TYPE_LOGIN_WINDOW "LoginWindow"
 
-GType            gsm_consolekit_get_type        (void) G_GNUC_CONST;
-
 GQuark           gsm_consolekit_error_quark     (void);
 
 GsmConsolekit   *gsm_consolekit_new             (void) G_GNUC_MALLOC;

--- a/mate-session/gsm-inhibit-dialog.c
+++ b/mate-session/gsm-inhibit-dialog.c
@@ -84,8 +84,6 @@ enum {
         NUMBER_OF_COLUMNS
 };
 
-static void     gsm_inhibit_dialog_class_init  (GsmInhibitDialogClass *klass);
-static void     gsm_inhibit_dialog_init        (GsmInhibitDialog      *inhibit_dialog);
 static void     gsm_inhibit_dialog_finalize    (GObject               *object);
 
 G_DEFINE_TYPE (GsmInhibitDialog, gsm_inhibit_dialog, GTK_TYPE_DIALOG)

--- a/mate-session/gsm-manager.c
+++ b/mate-session/gsm-manager.c
@@ -171,8 +171,6 @@ enum {
 
 static guint signals [LAST_SIGNAL] = { 0 };
 
-static void     gsm_manager_class_init  (GsmManagerClass *klass);
-static void     gsm_manager_init        (GsmManager      *manager);
 static void     gsm_manager_finalize    (GObject         *object);
 
 static gboolean _log_out_is_locked_down     (GsmManager *manager);

--- a/mate-session/gsm-store.c
+++ b/mate-session/gsm-store.c
@@ -51,8 +51,6 @@ enum {
 
 static guint signals [LAST_SIGNAL] = { 0 };
 
-static void     gsm_store_class_init    (GsmStoreClass *klass);
-static void     gsm_store_init          (GsmStore      *store);
 static void     gsm_store_finalize      (GObject       *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (GsmStore, gsm_store, G_TYPE_OBJECT)

--- a/mate-session/gsm-store.h
+++ b/mate-session/gsm-store.h
@@ -51,7 +51,6 @@ typedef gboolean (*GsmStoreFunc) (const char *id,
                                   gpointer    user_data);
 
 GQuark              gsm_store_error_quark              (void);
-GType               gsm_store_get_type                 (void) G_GNUC_CONST;
 
 GsmStore *          gsm_store_new                      (void);
 

--- a/mate-session/gsm-systemd.c
+++ b/mate-session/gsm-systemd.c
@@ -65,8 +65,6 @@ enum {
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
-static void     gsm_systemd_class_init   (GsmSystemdClass *klass);
-static void     gsm_systemd_init         (GsmSystemd      *sd);
 static void     gsm_systemd_finalize     (GObject         *object);
 
 static void     gsm_systemd_free_dbus    (GsmSystemd      *manager);

--- a/mate-session/gsm-systemd.h
+++ b/mate-session/gsm-systemd.h
@@ -56,8 +56,6 @@ enum _GsmSystemdError {
 
 #define GSM_SYSTEMD_SESSION_TYPE_LOGIN_WINDOW "greeter"
 
-GType            gsm_systemd_get_type        (void) G_GNUC_CONST;
-
 GQuark           gsm_systemd_error_quark     (void);
 
 GsmSystemd      *gsm_systemd_new             (void) G_GNUC_MALLOC;

--- a/mate-session/gsm-xsmp-client.h
+++ b/mate-session/gsm-xsmp-client.h
@@ -53,8 +53,6 @@ struct _GsmXSMPClientClass
 
 };
 
-GType       gsm_xsmp_client_get_type             (void) G_GNUC_CONST;
-
 GsmClient  *gsm_xsmp_client_new                  (IceConn         ice_conn);
 
 void        gsm_xsmp_client_connect              (GsmXSMPClient  *client,

--- a/mate-session/gsm-xsmp-server.c
+++ b/mate-session/gsm-xsmp-server.c
@@ -77,8 +77,6 @@ enum {
         PROP_CLIENT_STORE
 };
 
-static void     gsm_xsmp_server_class_init  (GsmXsmpServerClass *klass);
-static void     gsm_xsmp_server_init        (GsmXsmpServer      *xsmp_server);
 static void     gsm_xsmp_server_finalize    (GObject         *object);
 
 static gpointer xsmp_server_object = NULL;

--- a/mate-session/mdm-signal-handler.c
+++ b/mate-session/mdm-signal-handler.c
@@ -64,9 +64,7 @@ struct _MdmSignalHandler {
 	gpointer fatal_data;
 };
 
-static void mdm_signal_handler_class_init(MdmSignalHandlerClass* klass);
-static void mdm_signal_handler_init(MdmSignalHandler* signal_handler);
-static void mdm_signal_handler_finalize(GObject* object);
+static void mdm_signal_handler_finalize (GObject* object);
 
 static gpointer signal_handler_object = NULL;
 static int signal_pipes[2];


### PR DESCRIPTION
Fixes the warnings:

[mate-session-manager-Wredundant-decls.txt](https://github.com/mate-desktop/mate-session-manager/files/3964183/mate-session-manager-Wredundant-decls.txt)