### PR TITLE
main: allow turning on debugging from environment variable

### DIFF
--- a/mate-session/main.c
+++ b/mate-session/main.c
@@ -606,6 +606,7 @@ int main(int argc, char** argv)
 	MdmSignalHandler* signal_handler;
 	static char** override_autostart_dirs = NULL;
 	gboolean gl_failed = FALSE;
+	const char *debug_string = NULL;
 
 	static GOptionEntry entries[] = {
 		{"autostart", 'a', 0, G_OPTION_ARG_STRING_ARRAY, &override_autostart_dirs, N_("Override standard autostart directories"), NULL},
@@ -625,6 +626,10 @@ int main(int argc, char** argv)
 	bindtextdomain(GETTEXT_PACKAGE, LOCALE_DIR);
 	bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
 	textdomain(GETTEXT_PACKAGE);
+
+	debug_string = g_getenv ("MATE_SESSION_DEBUG");
+	if (debug_string != NULL)
+		debug = atoi (debug_string) == 1;
 
 	sa.sa_handler = SIG_IGN;
 	sa.sa_flags = 0;


### PR DESCRIPTION
This commit lets users set the environment variable `MATE_SESSION_DEBUG` to 1 in order to enable debugging.

Having to pass the argument option `--debug` is pretty onerous for the user given the user doesn't normally run mate-session directly.

[gnome-session-manager](https://gitlab.gnome.org/GNOME/gnome-session/blob/master/gnome-session/main.c#L435) has a similar feature.