### PR TITLE
Log Out / Shut Down dialogs: Restore classic GTK+ 2 appearance

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -67,7 +67,7 @@ requires:
     - make
     - mate-common
     - mesa-libGLES-devel
-    - pangox-compat-devel
+    - pango-devel
     - redhat-rpm-config
     - systemd-devel
     - xmlto

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,4 +71,4 @@ env:
   - DISTRO="archlinux:latest"
   - DISTRO="debian:testing"
   - DISTRO="fedora:latest"
-  - DISTRO="ubuntu:devel"
+  - DISTRO="ubuntu:rolling"

--- a/mate-session/gsm-logout-dialog.c
+++ b/mate-session/gsm-logout-dialog.c
@@ -409,6 +409,7 @@ gsm_get_dialog (GsmDialogLogoutType type,
                 guint32             activate_time)
 {
         GsmLogoutDialog *logout_dialog;
+        GtkWidget       *button_box;
         GtkWidget       *grid;
         GtkWidget       *dialog_icon;
         GtkSizeGroup    *size_group;
@@ -425,6 +426,13 @@ gsm_get_dialog (GsmDialogLogoutType type,
 
         gtk_window_set_title (GTK_WINDOW (logout_dialog), "");
         gtk_window_set_resizable (GTK_WINDOW (logout_dialog), FALSE);
+
+        /*
+         * The following 2 lines are to stretch out the buttons at the bottom
+         * of the dialog, as is in vogue in GTK+ 3:
+         */
+        button_box = gtk_dialog_get_action_area (GTK_DIALOG (logout_dialog));
+        gtk_button_box_set_layout (GTK_BUTTON_BOX (button_box), GTK_BUTTONBOX_EXPAND);
 
         logout_dialog->type = type;
 

--- a/mate-session/gsm-logout-dialog.c
+++ b/mate-session/gsm-logout-dialog.c
@@ -2,7 +2,6 @@
  *
  * Copyright (C) 2006 Vincent Untz
  * Copyright (C) 2008 Red Hat, Inc.
- * Copyright (C) 2020 Gordon N. Squash.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -21,7 +20,6 @@
  *
  * Authors:
  *	Vincent Untz <vuntz@gnome.org>
- *      Gordon N. Squash
  */
 
 #include <config.h>

--- a/mate-session/gsm-logout-dialog.h
+++ b/mate-session/gsm-logout-dialog.h
@@ -1,7 +1,6 @@
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
  *
  * Copyright (C) 2006 Vincent Untz
- * Copyright (C) 2020 Gordon N. Squash.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -20,7 +19,6 @@
  *
  * Authors:
  *	Vincent Untz <vuntz@gnome.org>
- *      Gordon N. Squash
  */
 
 #ifndef __GSM_LOGOUT_DIALOG_H__


### PR DESCRIPTION
While perusing [this thread on the Ubuntu MATE forum](https://ubuntu-mate.community/t/gtk3-regressions-from-a-gtk2-perspective/19511/56),
I noticed a group of many fellow MATE users who were discontented with how
GTK+ 3 styles message dialogs, the class of dialog used by the Log Out and
Shut Down dialogs in the MATE Session Manager.  The chief complaints made by
users were that GTK+ 3 does not display an icon next to the dialog contents,
that the buttons on the bottom of the dialog are overly large, and that --
possibly most importantly -- progress bars display their "progress text"
above the progress bar, not overlapping the progress bar as was the case in
GTK+ 2.  All manner of workarounds were proposed, and suffice it to say that
none were deemed good enough to attract considerable attention.

I tweaked the code for the Log Out and Shut Down dialogs considerably in this
commit to make the dialogs look very similar to the old GTK+ 2 dialogs of the
past.  First off, I subclassed GtkDialog (instead of GtkMessageDialog) and
added a grid to the dialog, placing an image and two label widgets inside the
grid to simulate the old GtkMessageDialog appearance.  Second, by means of
subclassing GtkDialog (as opposed to GtkMessageDialog), I gained the GTK+
2-esque button layout for free -- even in GTK+ 3 the button layout used by
GTK+ 2 dialogs is still used by default in GtkDialog but not GtkMessageDialog.
Third, I used a GtkProgressBar and GtkLabel packed into a GtkOverlay to
display the overlapping text, and a GtkSizeGroup to ensure the text is not
cut off by the small size of the progress bar.

Last but not least, GTK+ 3 progress bars have the frustrating property that
not the progress indicator, but instead a bunch of empty space, will appear
above them when they are allocated more screen space than their natural
size -- this is completely different from most GTK widgets which will expand
their "content" areas as the allocation is expanded, like the GtkButton
widget does.  This may not seem like a big deal, but it sure is if the user
set the text size larger than ~12pt (or with Adwaita, which has tiny progress
bars, probably .5pt).  In such a case the text will cover the entire progress
bar, and the top of the text will appear *above* the progress bar.  That does
not enhance accessibility!  To work around this, I used a kludge which
attaches a signal handler to the `size-allocate` signal emitted by the
GtkLabel.  When the signal handler is executed, it applies some simple CSS
to the progress bar, basically modifying the `min-height` property of the
progress indicator to equal the allocated height of the label:

        progressbar trough,
        progressbar progress
        {
          min-height: %dpx;
        }

The `%d` is replaced with the allocated height of the label.

Examples of the new look:

![20201030-log-out](https://user-images.githubusercontent.com/66928007/98039361-92f5c600-1dec-11eb-87b9-3d26c7e57ca0.png)
![20201030-shut-down](https://user-images.githubusercontent.com/66928007/98039369-96894d00-1dec-11eb-93b8-b6574658bc64.png)

And then as proof that the progress bars are resized properly, here's some extreme examples with 36-point font:

![20201030-log-out-36pt-font](https://user-images.githubusercontent.com/66928007/98039424-af91fe00-1dec-11eb-8f0f-5378ce886cbc.png)
![20201030-shut-down-36pt-font](https://user-images.githubusercontent.com/66928007/98039431-b3258500-1dec-11eb-8db1-c977e919935d.png)
