### PR TITLE
Remove warning -Wshadow

### DIFF
--- a/capplet/gsp-app-manager.c
+++ b/capplet/gsp-app-manager.c
@@ -28,8 +28,6 @@
 
 #include "gsp-app-manager.h"
 
-static GspAppManager *manager = NULL;
-
 typedef struct {
         char         *dir;
         int           index;
@@ -599,6 +597,8 @@ gsp_app_manager_find_app_with_basename (GspAppManager *manager,
 GspAppManager *
 gsp_app_manager_get (void)
 {
+        static GspAppManager *manager = NULL;
+
         if (manager == NULL) {
                 manager = g_object_new (GSP_TYPE_APP_MANAGER, NULL);
                 return manager;

--- a/mate-session/gsm-manager.c
+++ b/mate-session/gsm-manager.c
@@ -2172,13 +2172,13 @@ on_xsmp_client_register_request (GsmXSMPClient *client,
         if (IS_STRING_EMPTY (*id)) {
                 new_id = gsm_util_generate_startup_id ();
         } else {
-                GsmClient *client;
+                GsmClient *sm_client;
 
-                client = (GsmClient *)gsm_store_find (priv->clients,
-                                                      (GsmStoreFunc)_client_has_startup_id,
-                                                      *id);
+                sm_client = (GsmClient *)gsm_store_find (priv->clients,
+                                                         (GsmStoreFunc)_client_has_startup_id,
+                                                         *id);
                 /* We can't have two clients with the same id. */
-                if (client != NULL) {
+                if (sm_client != NULL) {
                         goto out;
                 }
 

--- a/mate-session/gsm-xsmp-server.c
+++ b/mate-session/gsm-xsmp-server.c
@@ -509,9 +509,9 @@ update_iceauthority (GsmXsmpServer *server,
         }
 
         for (e = entries; e; e = e->next) {
-                IceAuthFileEntry *auth_entry = e->data;
-                IceWriteAuthFileEntry (fp, auth_entry);
-                IceFreeAuthFileEntry (auth_entry);
+                IceAuthFileEntry *auth_file_entry = e->data;
+                IceWriteAuthFileEntry (fp, auth_file_entry);
+                IceFreeAuthFileEntry (auth_file_entry);
         }
         g_slist_free (entries);
 


### PR DESCRIPTION
```
gsm-xsmp-server.c:512:35: warning: declaration of 'auth_entry' shadows a previous local [-Wshadow]
  512 |                 IceAuthFileEntry *auth_entry = e->data;
      |                                   ^~~~~~~~~~
--
gsm-manager.c:2175:28: warning: declaration of 'client' shadows a parameter [-Wshadow]
 2175 |                 GsmClient *client;
      |                            ^~~~~~
--
gsp-app-manager.c:127:38: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  127 | gsp_app_manager_init (GspAppManager *manager)
      |                       ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:139:24: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  139 |         GspAppManager *manager;
      |                        ^~~~~~~
--
gsp-app-manager.c:161:24: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  161 |         GspAppManager *manager;
      |                        ^~~~~~~
--
gsp-app-manager.c:181:45: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  181 | _gsp_app_manager_emit_added (GspAppManager *manager,
      |                              ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:189:47: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  189 | _gsp_app_manager_emit_removed (GspAppManager *manager,
      |                                ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:201:47: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  201 | gsp_app_manager_get_dir_index (GspAppManager *manager,
      |                                ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:224:41: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  224 | gsp_app_manager_get_dir (GspAppManager *manager,
      |                          ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:246:57: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  246 | _gsp_app_manager_find_dir_with_basename (GspAppManager *manager,
      |                                          ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:294:48: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  294 | _gsp_app_manager_handle_delete (GspAppManager *manager,
      |                                 ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:375:24: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  375 |         GspAppManager *manager;
      |                        ^~~~~~~
--
gsp-app-manager.c:448:48: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  448 | _gsp_app_manager_fill_from_dir (GspAppManager *manager,
      |                                 ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:494:38: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  494 | gsp_app_manager_fill (GspAppManager *manager)
      |                       ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:534:44: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  534 |                             GspAppManager *manager)
      |                             ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:543:46: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  543 | _gsp_app_manager_app_removed (GspAppManager *manager,
      |                               ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:555:37: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  555 | gsp_app_manager_add (GspAppManager *manager,
      |                      ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:574:56: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  574 | gsp_app_manager_find_app_with_basename (GspAppManager *manager,
      |                                         ~~~~~~~~~~~~~~~^~~~~~~
--
gsp-app-manager.c:611:42: warning: declaration of 'manager' shadows a global declaration [-Wshadow]
  611 | gsp_app_manager_get_apps (GspAppManager *manager)
      |                           ~~~~~~~~~~~~~~~^~~~~~~
```