### PR TITLE
build: set GETTEXT_PACKAGE=AC_PACKAGE_NAME

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -224,7 +224,7 @@ AC_PATH_PROG([XSLTPROC], [xsltproc])
 dnl ====================================================================
 dnl Language Support
 dnl ====================================================================
-GETTEXT_PACKAGE=mate-session-manager
+GETTEXT_PACKAGE=AC_PACKAGE_NAME
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE",
                    [The gettext translation domain])
 AC_SUBST(GETTEXT_PACKAGE)


### PR DESCRIPTION
Test:
```
$ ./autogen.sh --prefix=/usr && grep GETTEXT_PACKAGE config.h
<cut>
#define GETTEXT_PACKAGE "mate-session-manager"
```