### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/tools/mate-session-check-accelerated-gl-helper.c
+++ b/tools/mate-session-check-accelerated-gl-helper.c
@@ -439,7 +439,7 @@ static gboolean print_renderer = FALSE;
 
 static const GOptionEntry entries[] = {
         { "print-renderer", 'p', 0, G_OPTION_ARG_NONE, &print_renderer, "Print GL renderer name", NULL },
-        { NULL },
+        { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL },
 };
 
 int

--- a/tools/mate-session-check-accelerated-gles-helper.c
+++ b/tools/mate-session-check-accelerated-gles-helper.c
@@ -193,7 +193,7 @@ static gboolean print_renderer = FALSE;
 
 static const GOptionEntry entries[] = {
         { "print-renderer", 'p', 0, G_OPTION_ARG_NONE, &print_renderer, "Print EGL renderer name", NULL },
-        { NULL },
+        { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL },
 };
 
 int

--- a/tools/mate-session-save.c
+++ b/tools/mate-session-save.c
@@ -73,7 +73,7 @@ static GOptionEntry options[] = {
 	{"session-name", 's', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &session_name, N_("Set the current session name"), N_("NAME")},
 	{"kill", '\0', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &kill_session, N_("Kill session"), NULL},
 	{"silent", '\0', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &no_interaction, N_("Do not require confirmation"), NULL},
-	{NULL}
+	{NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}
 };
 
 static void display_error(const char* message)


### PR DESCRIPTION
```
mate-session-save.c:76:7: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        {NULL}
             ^
--
mate-session-check-accelerated-gl-helper.c:442:16: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL },
               ^
--
mate-session-check-accelerated-gles-helper.c:196:16: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL },
               ^
```