### PR TITLE
g_key_file_save_to_file () is available from glib 2.40

### DIFF
--- a/capplet/gsp-app.c
+++ b/capplet/gsp-app.c
@@ -493,7 +493,7 @@ _gsp_app_save (gpointer data)
         }
 
         _gsp_ensure_user_autostart_dir ();
-        if (gsp_key_file_to_file (keyfile, priv->path, NULL)) {
+        if (g_key_file_save_to_file (keyfile, priv->path, NULL)) {
                 priv->skip_next_monitor_event = TRUE;
                 _gsp_app_save_done_success (app);
         } else {

--- a/capplet/gsp-keyfile.c
+++ b/capplet/gsp-keyfile.c
@@ -43,39 +43,6 @@ gsp_key_file_populate (GKeyFile *keyfile)
                                  "/bin/false");
 }
 
-//FIXME: kill this when bug #309224 is fixed
-gboolean
-gsp_key_file_to_file (GKeyFile     *keyfile,
-                      const gchar  *path,
-                      GError      **error)
-{
-        GError  *write_error;
-        gchar   *data;
-        gsize    length;
-        gboolean res;
-
-        g_return_val_if_fail (keyfile != NULL, FALSE);
-        g_return_val_if_fail (path != NULL, FALSE);
-
-        write_error = NULL;
-        data = g_key_file_to_data (keyfile, &length, &write_error);
-
-        if (write_error) {
-                g_propagate_error (error, write_error);
-                return FALSE;
-        }
-
-        res = g_file_set_contents (path, data, length, &write_error);
-        g_free (data);
-
-        if (write_error) {
-                g_propagate_error (error, write_error);
-                return FALSE;
-        }
-
-        return res;
-}
-
 gboolean
 gsp_key_file_get_boolean (GKeyFile    *keyfile,
                           const gchar *key,

--- a/capplet/gsp-keyfile.h
+++ b/capplet/gsp-keyfile.h
@@ -38,10 +38,6 @@ extern "C" {
 
 void      gsp_key_file_populate        (GKeyFile *keyfile);
 
-gboolean  gsp_key_file_to_file         (GKeyFile       *keyfile,
-                                        const gchar    *path,
-                                        GError        **error);
-
 gboolean gsp_key_file_get_boolean      (GKeyFile       *keyfile,
                                         const gchar    *key,
                                         gboolean        default_value);


### PR DESCRIPTION
https://bugzilla.gnome.org/show_bug.cgi?id=309224