### PR TITLE
Fix implicit conversion changes signedness: 'gboolean' to 'guint'

### DIFF
--- a/mate-session/gsm-consolekit.c
+++ b/mate-session/gsm-consolekit.c
@@ -245,7 +245,7 @@ gsm_consolekit_ensure_ck_connection (GsmConsolekit  *manager,
 
 out:
         if (priv->is_connected != is_connected) {
-                priv->is_connected = is_connected;
+                priv->is_connected = (is_connected != FALSE);
                 g_object_notify (G_OBJECT (manager), "is-connected");
         }
 

--- a/mate-session/gsm-systemd.c
+++ b/mate-session/gsm-systemd.c
@@ -245,7 +245,7 @@ gsm_systemd_ensure_sd_connection (GsmSystemd  *manager,
 
 out:
     if (priv->is_connected != is_connected) {
-        priv->is_connected = is_connected;
+        priv->is_connected = (is_connected != FALSE);
         g_object_notify (G_OBJECT (manager), "is-connected");
     }
 

--- a/mate-session/gsm-xsmp-client.c
+++ b/mate-session/gsm-xsmp-client.c
@@ -439,7 +439,7 @@ do_save_yourself (GsmXSMPClient *client,
                 g_debug ("GsmXSMPClient:   queuing new SaveYourself for '%s'",
                          priv->description);
                 priv->next_save_yourself = save_type;
-                priv->next_save_yourself_allow_interact = allow_interact;
+                priv->next_save_yourself_allow_interact = (allow_interact != FALSE);
         } else {
                 priv->current_save_yourself = save_type;
                 /* make sure we don't have anything queued */


### PR DESCRIPTION
```
git submodule init
git submodule update --recursive --remote
CFLAGS="-Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
```
gsm-xsmp-client.c:442:59: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                priv->next_save_yourself_allow_interact = allow_interact;
                                                        ~ ^~~~~~~~~~~~~~
--
gsm-consolekit.c:248:38: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint32' (aka 'unsigned int') [-Wsign-conversion]
                priv->is_connected = is_connected;
                                   ~ ^~~~~~~~~~~~
--
gsm-systemd.c:248:30: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint32' (aka 'unsigned int') [-Wsign-conversion]
        priv->is_connected = is_connected;
                           ~ ^~~~~~~~~~~~
```