### PR TITLE
Blacklist some session-specific variables (with corrected author name)

### DIFF
--- a/mate-session/gsm-util.c
+++ b/mate-session/gsm-util.c
@@ -39,6 +39,13 @@
 
 static gchar *_saved_session_dir = NULL;
 
+static const char * const variable_blacklist[] = {
+    "XDG_SEAT",
+    "XDG_SESSION_ID",
+    "XDG_VTNR",
+    NULL
+};
+
 gchar **
 gsm_get_screen_locker_command (void)
 {
@@ -536,6 +543,9 @@ gsm_util_export_activation_environment (GError     **error)
                 const char *entry_name = entry_names[i];
                 const char *entry_value = g_getenv (entry_name);
 
+                if (g_strv_contains (variable_blacklist, entry_name))
+                    continue;
+
                 if (!g_utf8_validate (entry_name, -1, NULL))
                     continue;
 
@@ -603,8 +613,13 @@ gsm_util_export_user_environment (GError     **error)
                 return FALSE;
         }
 
+        entries = g_get_environ ();
+
+        for (; variable_blacklist[i] != NULL; i++)
+                entries = g_environ_unsetenv (entries, variable_blacklist[i]);
+
         g_variant_builder_init (&builder, G_VARIANT_TYPE ("as"));
-        for (entries = g_get_environ (); entries[i] != NULL; i++) {
+        for (i = 0; entries[i] != NULL; i++) {
                 const char *entry = entries[i];
 
                 if (!g_utf8_validate (entry, -1, NULL))


### PR DESCRIPTION
Same as https://github.com/mate-desktop/mate-session-manager/pull/282
But with corrected author name from gnome.

Things like XDG_SESSION_ID should not be uploaded to the environment.
For example this is broken currently:

  1. SSH to your machine
  2. Log in to MATE Shell
  3. Log out
  4. Log in again
  5. Lock the screen
  6. Try to unlock

You can't, and this is because the XDG_SESSION_ID from the first session
(step 2) has leaked through to the second one (step 4), and so MATE
Shell is listening to the `logind` `UnlockSession` signal for the wrong
session. The SSH session established in step 1 serves to keep the
`systemd --user` instance alive, so that the state is not torn down
between logins.

Patch from GNOME by Iain Lane <iainl@gnome.org>