### PR TITLE
main: fix double free on gl_renderer

### DIFF
--- a/mate-session/main.c
+++ b/mate-session/main.c
@@ -759,7 +759,6 @@ int main(int argc, char** argv)
 
 	gsm_xsmp_server_start(xsmp_server);
 	_gsm_manager_set_renderer (manager, gl_renderer);
-	g_free (gl_renderer);
 	gsm_manager_start(manager);
 
 	gtk_main();


### PR DESCRIPTION
Fixes: 1263384 ("mate-session: fix memory leak")
Fixes: #304