### PR TITLE
Use g_info() for "screensaver left the bus" message

### DIFF
--- a/mate-session/gsm-presence.c
+++ b/mate-session/gsm-presence.c
@@ -201,7 +201,7 @@ on_screensaver_proxy_destroy (GObject     *proxy,
 {
         GsmPresencePrivate *priv;
 
-        g_warning ("Detected that screensaver has left the bus");
+        g_info ("Detected that screensaver has left the bus");
         priv = gsm_presence_get_instance_private (presence);
 
         priv->screensaver_proxy = NULL;


### PR DESCRIPTION
This message is only useful for people developing screensavers, but occurs normally when the user logs out.

Change it to a g_info() message, so screensaver devs can find it but normal users don't think they have a bug.