### PR TITLE
Fix unused variable warnings

### DIFF
--- a/mate-session/gs-idle-monitor.c
+++ b/mate-session/gs-idle-monitor.c
@@ -104,7 +104,7 @@ gs_idle_monitor_dispose (GObject *object)
 }
 
 static gboolean
-_find_alarm (gpointer            key,
+_find_alarm (gpointer            key G_GNUC_UNUSED,
              GSIdleMonitorWatch *watch,
              XSyncAlarm         *alarm)
 {
@@ -217,7 +217,7 @@ handle_alarm_notify_event (GSIdleMonitor         *monitor,
 
 static GdkFilterReturn
 xevent_filter (GdkXEvent     *xevent,
-               GdkEvent      *event,
+               GdkEvent      *event G_GNUC_UNUSED,
                GSIdleMonitor *monitor)
 {
         XEvent                *ev;

--- a/mate-session/gsm-app.c
+++ b/mate-session/gsm-app.c
@@ -134,7 +134,7 @@ gsm_app_constructor (GType                  type,
 }
 
 static void
-gsm_app_init (GsmApp *app)
+gsm_app_init (GsmApp *app G_GNUC_UNUSED)
 {
 }
 
@@ -185,7 +185,7 @@ static void
 gsm_app_set_property (GObject      *object,
                       guint         prop_id,
                       const GValue *value,
-                      GParamSpec   *pspec)
+                      GParamSpec   *pspec G_GNUC_UNUSED)
 {
         GsmApp *app = GSM_APP (object);
 
@@ -208,7 +208,7 @@ static void
 gsm_app_get_property (GObject    *object,
                       guint       prop_id,
                       GValue     *value,
-                      GParamSpec *pspec)
+                      GParamSpec *pspec G_GNUC_UNUSED)
 {
         GsmAppPrivate *priv;
         GsmApp *app = GSM_APP (object);

--- a/mate-session/gsm-autostart-app.c
+++ b/mate-session/gsm-autostart-app.c
@@ -178,9 +178,9 @@ parse_condition_string (const char *condition_string,
 }
 
 static void
-if_exists_condition_cb (GFileMonitor     *monitor,
-                        GFile            *file,
-                        GFile            *other_file,
+if_exists_condition_cb (GFileMonitor     *monitor G_GNUC_UNUSED,
+                        GFile            *file G_GNUC_UNUSED,
+                        GFile            *other_file G_GNUC_UNUSED,
                         GFileMonitorEvent event,
                         GsmApp           *app)
 {
@@ -209,9 +209,9 @@ if_exists_condition_cb (GFileMonitor     *monitor,
 }
 
 static void
-unless_exists_condition_cb (GFileMonitor     *monitor,
-                            GFile            *file,
-                            GFile            *other_file,
+unless_exists_condition_cb (GFileMonitor     *monitor G_GNUC_UNUSED,
+                            GFile            *file G_GNUC_UNUSED,
+                            GFile            *other_file G_GNUC_UNUSED,
                             GFileMonitorEvent event,
                             GsmApp           *app)
 {
@@ -802,8 +802,8 @@ autostart_app_stop_spawn (GsmAutostartApp *app,
 }
 
 static gboolean
-autostart_app_stop_activate (GsmAutostartApp *app,
-                             GError         **error)
+autostart_app_stop_activate (GsmAutostartApp *app G_GNUC_UNUSED,
+                             GError         **error G_GNUC_UNUSED)
 {
         return TRUE;
 }
@@ -896,7 +896,7 @@ autostart_app_start_spawn (GsmAutostartApp *app,
 }
 
 static void
-start_notify (GObject *source_object,
+start_notify (GObject *source_object G_GNUC_UNUSED,
               GAsyncResult *res,
               gpointer data)
 {

--- a/mate-session/gsm-client.c
+++ b/mate-session/gsm-client.c
@@ -153,7 +153,7 @@ gsm_client_constructor (GType                  type,
 }
 
 static void
-gsm_client_init (GsmClient *client)
+gsm_client_init (GsmClient *client G_GNUC_UNUSED)
 {
 }
 
@@ -286,7 +286,7 @@ gsm_client_get_property (GObject    *object,
 
 static gboolean
 default_stop (GsmClient *client,
-              GError   **error)
+              GError   **error G_GNUC_UNUSED)
 {
         g_return_val_if_fail (GSM_IS_CLIENT (client), FALSE);
 

--- a/mate-session/gsm-consolekit.c
+++ b/mate-session/gsm-consolekit.c
@@ -150,7 +150,7 @@ gsm_consolekit_class_init (GsmConsolekitClass *manager_class)
 }
 
 static DBusHandlerResult
-gsm_consolekit_dbus_filter (DBusConnection *connection,
+gsm_consolekit_dbus_filter (DBusConnection *connection G_GNUC_UNUSED,
                             DBusMessage    *message,
                             void           *user_data)
 {
@@ -272,10 +272,10 @@ out:
 }
 
 static void
-gsm_consolekit_on_name_owner_changed (DBusGProxy    *bus_proxy,
+gsm_consolekit_on_name_owner_changed (DBusGProxy    *bus_proxy G_GNUC_UNUSED,
                                       const char    *name,
-                                      const char    *prev_owner,
-                                      const char    *new_owner,
+                                      const char    *prev_owner G_GNUC_UNUSED,
+                                      const char    *new_owner G_GNUC_UNUSED,
                                       GsmConsolekit *manager)
 {
         GsmConsolekitPrivate *priv;

--- a/mate-session/gsm-dbus-client.c
+++ b/mate-session/gsm-dbus-client.c
@@ -411,7 +411,7 @@ gsm_dbus_client_finalize (GObject *object)
 
 static GKeyFile *
 dbus_client_save (GsmClient *client,
-                  GError   **error)
+                  GError   **error G_GNUC_UNUSED)
 {
         g_debug ("GsmDBusClient: saving client with id %s",
                  gsm_client_peek_id (client));
@@ -424,7 +424,7 @@ dbus_client_save (GsmClient *client,
 
 static gboolean
 dbus_client_stop (GsmClient *client,
-                  GError   **error)
+                  GError   **error G_GNUC_UNUSED)
 {
         GsmDBusClient  *dbus_client = (GsmDBusClient *) client;
         DBusMessage    *message;
@@ -458,7 +458,7 @@ dbus_client_stop (GsmClient *client,
 }
 
 static char *
-dbus_client_get_app_name (GsmClient *client)
+dbus_client_get_app_name (GsmClient *client G_GNUC_UNUSED)
 {
         /* Always use app-id instead */
         return NULL;
@@ -541,7 +541,7 @@ dbus_client_query_end_session (GsmClient *client,
 static gboolean
 dbus_client_end_session (GsmClient *client,
                          guint      flags,
-                         GError   **error)
+                         GError   **error G_GNUC_UNUSED)
 {
         GsmDBusClient  *dbus_client = (GsmDBusClient *) client;
         DBusMessage    *message;

--- a/mate-session/gsm-manager.c
+++ b/mate-session/gsm-manager.c
@@ -229,9 +229,9 @@ gsm_manager_error_get_type (void)
 }
 
 static gboolean
-_debug_client (const char *id,
+_debug_client (const char *id G_GNUC_UNUSED,
                GsmClient  *client,
-               GsmManager *manager)
+               GsmManager *manager G_GNUC_UNUSED)
 {
         g_debug ("GsmManager: Client %s", gsm_client_peek_id (client));
         return FALSE;
@@ -248,9 +248,9 @@ debug_clients (GsmManager *manager)
 }
 
 static gboolean
-_debug_inhibitor (const char    *id,
+_debug_inhibitor (const char    *id G_GNUC_UNUSED,
                   GsmInhibitor  *inhibitor,
-                  GsmManager    *manager)
+                  GsmManager    *manager G_GNUC_UNUSED)
 {
         g_debug ("GsmManager: Inhibitor app:%s client:%s bus-name:%s reason:%s",
                  gsm_inhibitor_peek_app_id (inhibitor),
@@ -272,7 +272,7 @@ debug_inhibitors (GsmManager *manager)
 }
 
 static gboolean
-_find_by_cookie (const char   *id,
+_find_by_cookie (const char   *id G_GNUC_UNUSED,
                  GsmInhibitor *inhibitor,
                  guint        *cookie_ap)
 {
@@ -284,7 +284,7 @@ _find_by_cookie (const char   *id,
 }
 
 static gboolean
-_find_by_startup_id (const char *id,
+_find_by_startup_id (const char *id G_GNUC_UNUSED,
                      GsmClient  *client,
                      const char *startup_id_a)
 {
@@ -793,7 +793,7 @@ _client_end_session (GsmClient            *client,
 }
 
 static gboolean
-_client_end_session_helper (const char           *id,
+_client_end_session_helper (const char           *id G_GNUC_UNUSED,
                             GsmClient            *client,
                             ClientEndSessionData *data)
 {
@@ -869,9 +869,9 @@ do_phase_end_session_part_2 (GsmManager *manager)
 }
 
 static gboolean
-_client_stop (const char *id,
+_client_stop (const char *id G_GNUC_UNUSED,
               GsmClient  *client,
-              gpointer    user_data)
+              gpointer    user_data G_GNUC_UNUSED)
 {
         gboolean ret;
         GError  *error;
@@ -954,7 +954,7 @@ do_phase_exit (GsmManager *manager)
 }
 
 static gboolean
-_client_query_end_session (const char           *id,
+_client_query_end_session (const char           *id G_GNUC_UNUSED,
                            GsmClient            *client,
                            ClientEndSessionData *data)
 {
@@ -979,7 +979,7 @@ _client_query_end_session (const char           *id,
 }
 
 static gboolean
-inhibitor_has_flag (gpointer      key,
+inhibitor_has_flag (gpointer      key G_GNUC_UNUSED,
                     GsmInhibitor *inhibitor,
                     gpointer      data)
 {
@@ -1036,9 +1036,9 @@ gsm_manager_is_idle_inhibited (GsmManager *manager)
 }
 
 static gboolean
-_client_cancel_end_session (const char *id,
+_client_cancel_end_session (const char *id G_GNUC_UNUSED,
                             GsmClient  *client,
-                            GsmManager *manager)
+                            GsmManager *manager G_GNUC_UNUSED)
 {
         gboolean res;
         GError  *error;
@@ -1054,9 +1054,9 @@ _client_cancel_end_session (const char *id,
 }
 
 static gboolean
-inhibitor_is_jit (gpointer      key,
+inhibitor_is_jit (gpointer      key G_GNUC_UNUSED,
                   GsmInhibitor *inhibitor,
-                  GsmManager   *manager)
+                  GsmManager   *manager G_GNUC_UNUSED)
 {
         gboolean    matches;
         const char *id;
@@ -1638,7 +1638,7 @@ start_phase (GsmManager *manager)
 }
 
 static gboolean
-_debug_app_for_phase (const char *id,
+_debug_app_for_phase (const char *id G_GNUC_UNUSED,
                       GsmApp     *app,
                       gpointer    data)
 {
@@ -1700,7 +1700,7 @@ _gsm_manager_set_renderer (GsmManager *manager,
 }
 
 static gboolean
-_app_has_app_id (const char   *id,
+_app_has_app_id (const char   *id G_GNUC_UNUSED,
                  GsmApp       *app,
                  const char   *app_id_a)
 {
@@ -1725,7 +1725,7 @@ find_app_for_app_id (GsmManager *manager,
 }
 
 static gboolean
-inhibitor_has_client_id (gpointer      key,
+inhibitor_has_client_id (gpointer      key G_GNUC_UNUSED,
                          GsmInhibitor *inhibitor,
                          const char   *client_id_a)
 {
@@ -1748,7 +1748,7 @@ inhibitor_has_client_id (gpointer      key,
 }
 
 static gboolean
-_app_has_startup_id (const char *id,
+_app_has_startup_id (const char *id G_GNUC_UNUSED,
                      GsmApp     *app,
                      const char *startup_id_a)
 {
@@ -1920,7 +1920,7 @@ typedef struct {
 } RemoveClientData;
 
 static gboolean
-_disconnect_dbus_client (const char       *id,
+_disconnect_dbus_client (const char       *id G_GNUC_UNUSED,
                          GsmClient        *client,
                          RemoveClientData *data)
 {
@@ -1982,7 +1982,7 @@ remove_clients_for_connection (GsmManager *manager,
 }
 
 static gboolean
-inhibitor_has_bus_name (gpointer          key,
+inhibitor_has_bus_name (gpointer          key G_GNUC_UNUSED,
                         GsmInhibitor     *inhibitor,
                         RemoveClientData *data)
 {
@@ -2129,7 +2129,7 @@ gsm_manager_set_failsafe (GsmManager *manager,
 }
 
 static gboolean
-_client_has_startup_id (const char *id,
+_client_has_startup_id (const char *id G_GNUC_UNUSED,
                         GsmClient  *client,
                         const char *startup_id_a)
 {
@@ -2405,7 +2405,7 @@ on_client_end_session_response (GsmClient  *client,
 }
 
 static void
-on_xsmp_client_logout_request (GsmXSMPClient *client,
+on_xsmp_client_logout_request (GsmXSMPClient *client G_GNUC_UNUSED,
                                gboolean       show_dialog,
                                GsmManager    *manager)
 {


### PR DESCRIPTION
Fix unused variable warnings with `G_GNUC_UNUSED`.