### PR TITLE
Fix long env vars

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,6 +120,12 @@ if test "x$with_systemd" != "xno" ; then
         AC_DEFINE(HAVE_SYSTEMD, 1, [systemd support])
         AC_SUBST(SYSTEMD_CFLAGS)
         AC_SUBST(SYSTEMD_LIBS)
+        PKG_CHECK_EXISTS([libsystemd],
+                         [systemd_pkgconfig=libsystemd],
+                         [systemd_pkgconfig=libsystemd-login])
+        PKG_CHECK_EXISTS([$systemd_pkgconfig >= 248],,
+                         [AC_DEFINE([SYSTEMD_STRICT_ENV], [1],
+                         [Use strict environment variable validation for systemd < 248])])
     fi
 fi
 AM_CONDITIONAL(HAVE_SYSTEMD, test "x$use_systemd" = "xyes")

--- a/mate-session/gsm-util.c
+++ b/mate-session/gsm-util.c
@@ -501,6 +501,13 @@ gsm_util_update_activation_environment (const char  *variable,
         return environment_updated;
 }
 
+#define ENV_NAME_PATTERN "[a-zA-Z_][a-zA-Z0-9_]*"
+#ifdef SYSTEMD_STRICT_ENV
+#define ENV_VALUE_PATTERN "(?:[ \t\n]|[^[:cntrl:]])*"
+#else
+#define ENV_VALUE_PATTERN ".*"
+#endif
+
 gboolean
 gsm_util_export_activation_environment (GError     **error)
 {
@@ -519,13 +526,14 @@ gsm_util_export_activation_environment (GError     **error)
                 return FALSE;
         }
 
-        name_regex = g_regex_new ("^[a-zA-Z_][a-zA-Z0-9_]*$", G_REGEX_OPTIMIZE, 0, error);
+        name_regex = g_regex_new ("^" ENV_NAME_PATTERN "$", G_REGEX_OPTIMIZE, 0, error);
 
         if (name_regex == NULL) {
                 return FALSE;
         }
 
-        value_regex = g_regex_new ("^(?:[ \t\n]|[^[:cntrl:]])*$", G_REGEX_OPTIMIZE, 0, error);
+
+        value_regex = g_regex_new ("^" ENV_VALUE_PATTERN "$", G_REGEX_OPTIMIZE, 0, error);
 
         if (value_regex == NULL) {
                 return FALSE;
@@ -597,7 +605,7 @@ gsm_util_export_user_environment (GError     **error)
                 return FALSE;
         }
 
-        regex = g_regex_new ("^[a-zA-Z_][a-zA-Z0-9_]*=(?:[ \t\n]|[^[:cntrl:]])*$", G_REGEX_OPTIMIZE, 0, error);
+        regex = g_regex_new ("^" ENV_NAME_PATTERN "=" ENV_VALUE_PATTERN "$", G_REGEX_OPTIMIZE, 0, error);
 
         if (regex == NULL) {
                 return FALSE;


### PR DESCRIPTION
For systemd >= 248, environment variable values can contain any characters.
For systemd < 248, values must not contain control characters (except space, tab, and newline).

These backports from gnome-session should address this:
- https://gitlab.gnome.org/GNOME/gnome-session/-/commit/fe22c4ee12922d790478bfe8b5b2e7c1313ca2f0
- https://gitlab.gnome.org/GNOME/gnome-session/-/commit/3b57d117f78ad06e56974b9512a394fd9ef13a07
- https://gitlab.gnome.org/GNOME/gnome-session/-/commit/cbc5e5de421359ee5642e44fa9ab670d705d23ea