### PR TITLE
Required components default fallback

### DIFF
--- a/data/mate-wm
+++ b/data/mate-wm
@@ -58,6 +58,14 @@ if [ "x$WINDOW_MANAGER" = "xcompiz" -o "x$DEFWM" = "xcompiz" ]; then
   fi
 fi
 
+#  Check WINDOW_MANAGER exists
+if [ -n "$WINDOW_MANAGER" ] ; then
+  if ! command -v "$WINDOW_MANAGER" > /dev/null 2>&1; then
+    echo "Window manager $WINDOW_MANAGER executable not found."
+    WINDOW_MANAGER=""
+  fi
+fi
+
 # Avoid looping if the session configuration tells us to use mate-wm or if
 # the user forces mate-wm via WINDOW_MANAGER
 if [ "x$WINDOW_MANAGER" = "xmate-wm" ]; then

--- a/mate-session/main.c
+++ b/mate-session/main.c
@@ -235,6 +235,56 @@ static void append_default_apps(GsmManager* manager, const char* default_session
 	g_strfreev (default_apps);
 }
 
+static void append_required_apps_add_component (GsmManager* manager, GSettings* settings_required_components, const char* component, gboolean is_recursive_call)
+{
+	char* default_provider;
+
+	default_provider = g_settings_get_string (settings_required_components, component);
+
+	g_debug ("main: %s looking for component: '%s'", component, default_provider);
+
+	if (default_provider != NULL)
+	{
+		char* app_path;
+
+		app_path = gsm_util_find_desktop_file_for_app_name(default_provider, NULL);
+
+		if (app_path != NULL)
+		{
+			gsm_manager_add_autostart_app(manager, app_path, component);
+		}
+		else
+		{
+			g_warning ("Unable to find provider '%s' of required component '%s'", default_provider, component);
+
+			if (default_provider[0] != '\0' && !is_recursive_call)
+			{
+				// possible reset component to default
+
+				const char *default_default_provider;
+				GVariant *g_settings_default_default;
+				g_settings_default_default = g_settings_get_default_value (settings_required_components, component);
+				default_default_provider = g_variant_get_string (g_settings_default_default, NULL);
+
+				if (default_default_provider[0] != '\0' && strcmp (default_default_provider, default_provider) != 0)
+				{
+					g_warning ("Reset required component '%s' to default", component);
+					g_settings_reset (settings_required_components, component);
+
+					append_required_apps_add_component(manager, settings_required_components, component, TRUE);
+				}
+
+				g_variant_unref (g_settings_default_default);
+			}
+
+		}
+
+		g_free(app_path);
+	}
+
+	g_free(default_provider);
+}
+
 static void append_required_apps(GsmManager* manager)
 {
 	gchar** required_components;
@@ -257,39 +307,11 @@ static void append_required_apps(GsmManager* manager)
 	{
 		for (i = 0; required_components[i]; i++)
 		{
-			char* default_provider;
-			const char* component;
-
 			if (IS_STRING_EMPTY((char*) required_components[i]))
 			{
 				continue;
 			}
-
-			component = required_components[i];
-
-			default_provider = g_settings_get_string (settings_required_components, component);
-
-			g_debug ("main: %s looking for component: '%s'", component, default_provider);
-
-			if (default_provider != NULL)
-			{
-				char* app_path;
-
-				app_path = gsm_util_find_desktop_file_for_app_name(default_provider, NULL);
-
-				if (app_path != NULL)
-				{
-					gsm_manager_add_autostart_app(manager, app_path, component);
-				}
-				else
-				{
-					g_warning("Unable to find provider '%s' of required component '%s'", default_provider, component);
-				}
-
-				g_free(app_path);
-			}
-
-			g_free(default_provider);
+			append_required_apps_add_component(manager, settings_required_components, required_components[i], FALSE);
 		}
 	}
 

--- a/mate-session/main.c
+++ b/mate-session/main.c
@@ -235,6 +235,60 @@ static void append_default_apps(GsmManager* manager, const char* default_session
 	g_strfreev (default_apps);
 }
 
+static void append_required_apps_add_component (GsmManager* manager, GSettings* settings_required_components, const char* component, gboolean is_recursive_call)
+{
+	char* default_provider;
+
+	default_provider = g_settings_get_string (settings_required_components, component);
+
+	g_debug ("main: %s looking for component: '%s'", component, default_provider);
+
+	if (default_provider != NULL)
+	{
+		char* app_path;
+
+		app_path = gsm_util_find_desktop_file_for_app_name (default_provider, NULL);
+
+		if (app_path != NULL)
+		{
+			gsm_manager_add_autostart_app (manager, app_path, component);
+		}
+		else
+		{
+			g_warning ("Unable to find provider '%s' of required component '%s'", default_provider, component);
+
+			if (default_provider[0] != '\0' && !is_recursive_call)
+			{
+				// possible reset component to default
+
+				const char *default_default_provider;
+				GVariant *schema_default;
+				schema_default = g_settings_get_default_value (settings_required_components, component);
+
+				if (schema_default != NULL)
+				{
+					default_default_provider = g_variant_get_string (schema_default, NULL);
+
+					if (default_default_provider[0] != '\0' && strcmp (default_default_provider, default_provider) != 0)
+					{
+						g_warning ("Reset required component '%s' to default", component);
+						g_settings_reset (settings_required_components, component);
+
+						append_required_apps_add_component (manager, settings_required_components, component, TRUE);
+					}
+
+					g_variant_unref (schema_default);
+				}
+			}
+
+		}
+
+		g_free (app_path);
+	}
+
+	g_free (default_provider);
+}
+
 static void append_required_apps(GsmManager* manager)
 {
 	gchar** required_components;
@@ -257,39 +311,11 @@ static void append_required_apps(GsmManager* manager)
 	{
 		for (i = 0; required_components[i]; i++)
 		{
-			char* default_provider;
-			const char* component;
-
 			if (IS_STRING_EMPTY((char*) required_components[i]))
 			{
 				continue;
 			}
-
-			component = required_components[i];
-
-			default_provider = g_settings_get_string (settings_required_components, component);
-
-			g_debug ("main: %s looking for component: '%s'", component, default_provider);
-
-			if (default_provider != NULL)
-			{
-				char* app_path;
-
-				app_path = gsm_util_find_desktop_file_for_app_name(default_provider, NULL);
-
-				if (app_path != NULL)
-				{
-					gsm_manager_add_autostart_app(manager, app_path, component);
-				}
-				else
-				{
-					g_warning("Unable to find provider '%s' of required component '%s'", default_provider, component);
-				}
-
-				g_free(app_path);
-			}
-
-			g_free(default_provider);
+			append_required_apps_add_component(manager, settings_required_components, required_components[i], FALSE);
 		}
 	}
 


### PR DESCRIPTION
Reset the `required components` to default, if not found. 
After uninstall a component, a fallback is need: will fix #324
_(( Required components are: dock, filemanager, panel, window manager. ))_

-------

Changes in file **mate-session/main.c** :
Reset will be done, in this case:
 - the executable was not found 
 - and the current value is not empty 
   - => this still allows the user to disable a component manual (= by set empty value) 
 - and the default value is not empty
 
-------
Additional just for the Windowmanager:
Changes in file **data/mate-wm** : 
- checks if the value from gsettings is usable (_`command`_) , 
- otherwise just ignore that value and continue the script normal (= will search for another window manager)

_(both shortly tested with older Mate Version 1.26 on Debian 13. ; I'm new in C-Language)_
