### PR TITLE
session: Add sound events for login and logout

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,26 @@ fi
 AM_CONDITIONAL([HAVE_GLESV2], [test "x$have_glesv2" = "xyes"])
 
 dnl ====================================================================
+dnl libcanberra (optional) for sound events
+dnl ====================================================================
+
+AC_ARG_WITH([libcanberra],
+    AS_HELP_STRING([--without-libcanberra], [Disable sound events (default: auto)]),
+    [with_libcanberra=$withval], [with_libcanberra=auto])
+
+have_libcanberra=no
+if test "x$with_libcanberra" != "xno"; then
+    PKG_CHECK_MODULES(LIBCANBERRA, libcanberra-gtk3,
+              [AC_DEFINE(HAVE_LIBCANBERRA, 1, [Define if libcanberra-gtk3 is available])
+              have_libcanberra=yes], have_libcanberra=no)
+    if test "x$have_libcanberra" = xno -a "x$with_libcanberra" = xyes; then
+        AC_MSG_ERROR([libcanberra support requested but library not found])
+    fi
+fi
+AC_SUBST(LIBCANBERRA_CFLAGS)
+AC_SUBST(LIBCANBERRA_LIBS)
+
+dnl ====================================================================
 dnl Option to set the default window manager
 dnl ====================================================================
 AC_ARG_WITH(default-wm,
@@ -385,5 +405,6 @@ echo "
         XTest support:            ${have_xtest}
         Build documentation:      ${enable_docbook_docs}
         Native Language support:  ${USE_NLS}
+        Libcanberra support:      ${have_libcanberra}
 
 "

--- a/mate-session/Makefile.am
+++ b/mate-session/Makefile.am
@@ -62,6 +62,7 @@ mate_session_CPPFLAGS =			\
 	$(SM_CFLAGS)				\
 	$(ICE_CFLAGS)				\
 	$(XEXT_CFLAGS)				\
+	$(LIBCANBERRA_CFLAGS)			\
 	-I$(top_srcdir)/mate-submodules/libegg			\
 	-DLOCALE_DIR=\""$(datadir)/locale"\"	\
 	-DDATA_DIR=\""$(datadir)/mate-session"\" \
@@ -81,7 +82,8 @@ mate_session_LDADD =				\
 	$(MATE_SESSION_LIBS)			\
 	$(SYSTEMD_LIBS)				\
 	$(LIBELOGIND_LIBS)			\
-	$(EXECINFO_LIBS)
+	$(EXECINFO_LIBS)			\
+	$(LIBCANBERRA_LIBS)
 
 libgsmutil_la_SOURCES =				\
 	gsm-util.c				\

--- a/mate-session/gsm-manager.c
+++ b/mate-session/gsm-manager.c
@@ -65,6 +65,10 @@
 #endif
 #include "gsm-session-save.h"
 
+#ifdef HAVE_LIBCANBERRA
+#include <canberra-gtk.h>
+#endif
+
 #define GSM_MANAGER_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GSM_TYPE_MANAGER, GsmManagerPrivate))
 
 #define GSM_MANAGER_DBUS_PATH "/org/gnome/SessionManager"
@@ -1548,6 +1552,13 @@ do_phase_query_end_session (GsmManager *manager)
         data.flags = 0;
         priv = gsm_manager_get_instance_private (manager);
 
+#ifdef HAVE_LIBCANBERRA
+        ca_context_play (ca_gtk_context_get (), 0,
+                         CA_PROP_EVENT_ID, "desktop-logout",
+                         CA_PROP_EVENT_DESCRIPTION, "Session logout",
+                         NULL);
+#endif
+
         if (priv->logout_mode == GSM_MANAGER_LOGOUT_MODE_FORCE) {
                 data.flags |= GSM_CLIENT_END_SESSION_FLAG_FORCEFUL;
         }
@@ -1620,6 +1631,12 @@ start_phase (GsmManager *manager)
                 break;
         case GSM_MANAGER_PHASE_RUNNING:
                 g_signal_emit (manager, signals[SESSION_RUNNING], 0);
+#ifdef HAVE_LIBCANBERRA
+                ca_context_play (ca_gtk_context_get (), 0,
+                                 CA_PROP_EVENT_ID, "desktop-login",
+                                 CA_PROP_EVENT_DESCRIPTION, "Session login",
+                                 NULL);
+#endif
                 update_idle (manager);
                 break;
         case GSM_MANAGER_PHASE_QUERY_END_SESSION:


### PR DESCRIPTION
Adds optional libcanberra support to play desktop-login and desktop-logout sound events during session start and end. Sound playback is controlled through the system sound theme configuration.

Fixes #328