### PR TITLE
session: restart non-client apps that set AutoRestart

### DIFF
--- a/mate-session/gsm-autostart-app.c
+++ b/mate-session/gsm-autostart-app.c
@@ -474,7 +474,18 @@ load_desktop_file (GsmAutostartApp *app)
                                                                   GSM_AUTOSTART_APP_AUTORESTART_KEY,
                                                                   NULL);
         } else {
-                priv->autorestart = FALSE;
+                /* Fall back to X-GNOME-AutoRestart for compatibility with
+                 * apps like Orca that set the GNOME key */
+                res = egg_desktop_file_has_key (priv->desktop_file,
+                                                "X-GNOME-AutoRestart",
+                                                NULL);
+                if (res) {
+                        priv->autorestart = egg_desktop_file_get_boolean (priv->desktop_file,
+                                                                          "X-GNOME-AutoRestart",
+                                                                          NULL);
+                } else {
+                        priv->autorestart = FALSE;
+                }
         }
 
         g_free (priv->condition_string);
@@ -1108,28 +1119,11 @@ gsm_autostart_app_has_autostart_condition (GsmApp     *app,
 static gboolean
 gsm_autostart_app_get_autorestart (GsmApp *app)
 {
-        gboolean res;
-        gboolean autorestart;
         GsmAutostartAppPrivate *priv;
 
         priv = gsm_autostart_app_get_instance_private (GSM_AUTOSTART_APP(app));
 
-        if (priv->desktop_file == NULL) {
-                return FALSE;
-        }
-
-        autorestart = FALSE;
-
-        res = egg_desktop_file_has_key (priv->desktop_file,
-                                        GSM_AUTOSTART_APP_AUTORESTART_KEY,
-                                        NULL);
-        if (res) {
-                autorestart = egg_desktop_file_get_boolean (priv->desktop_file,
-                                                            GSM_AUTOSTART_APP_AUTORESTART_KEY,
-                                                            NULL);
-        }
-
-        return autorestart;
+        return priv->autorestart;
 }
 
 static const char *

--- a/mate-session/gsm-manager.c
+++ b/mate-session/gsm-manager.c
@@ -4149,6 +4149,66 @@ gsm_manager_is_autostart_condition_handled (GsmManager *manager,
 }
 
 static void
+_app_restart (GsmManager *manager,
+              GsmApp     *app)
+{
+        GsmManagerPrivate *priv;
+        GsmClient *client;
+        const char *startup_id;
+        GError *error;
+        gboolean UNUSED_VARIABLE res;
+
+        priv = gsm_manager_get_instance_private (manager);
+
+        if (priv->phase >= GSM_MANAGER_PHASE_QUERY_END_SESSION) {
+                g_debug ("GsmManager: in shutdown, not restarting application");
+                return;
+        }
+
+        if (!gsm_app_peek_autorestart (app)) {
+                g_debug ("GsmManager: autorestart not set, not restarting application");
+                return;
+        }
+
+        /* If the app has a registered client, _disconnect_client will
+         * handle its restart. Skip here to avoid a double restart */
+        startup_id = gsm_app_peek_startup_id (app);
+        if (!IS_STRING_EMPTY (startup_id)) {
+                client = (GsmClient *)gsm_store_find (priv->clients,
+                                                       (GsmStoreFunc)_find_by_startup_id,
+                                                       (char *)startup_id);
+                if (client != NULL) {
+                        g_debug ("GsmManager: app '%s' has a registered client, skipping",
+                                 gsm_app_peek_app_id (app));
+                        return;
+                }
+        }
+
+        g_debug ("GsmManager: restarting app '%s'", gsm_app_peek_app_id (app));
+
+        error = NULL;
+        res = gsm_app_restart (app, &error);
+        if (error != NULL) {
+                g_warning ("Error on restarting app: %s", error->message);
+                g_error_free (error);
+        }
+}
+
+static void
+on_app_exited (GsmApp     *app,
+               GsmManager *manager)
+{
+        _app_restart (manager, app);
+}
+
+static void
+on_app_died (GsmApp     *app,
+             GsmManager *manager)
+{
+        _app_restart (manager, app);
+}
+
+static void
 append_app (GsmManager *manager,
             GsmApp     *app)
 {
@@ -4183,6 +4243,11 @@ append_app (GsmManager *manager,
         }
 
         gsm_store_add (priv->apps, id, G_OBJECT (app));
+
+        g_signal_connect (app, "exited",
+                          G_CALLBACK (on_app_exited), manager);
+        g_signal_connect (app, "died",
+                          G_CALLBACK (on_app_died), manager);
 }
 
 gboolean


### PR DESCRIPTION
Apps like Orca set `X-GNOME-AutoRestart=true` in their .desktop files expecting to be restarted after a crash. However, the restart logic only handled apps that registered as XSMP or D-Bus clients. Non-client apps emitted "died"/"exited" signals but nothing subscribed to them. This bug was inherited from gnome-session.

Connect the "died" and "exited" signals on autostart apps to trigger restart for non-client apps with AutoRestart enabled. Also fall back to `X-GNOME-AutoRestart` when `X-MATE-AutoRestart` is not present, for compatibility with apps that only set the GNOME key.

Fixes #321