### PR TITLE
app: Add respawn rate limiting to prevent CPU spinning

### DIFF
--- a/mate-session/gsm-app.c
+++ b/mate-session/gsm-app.c
@@ -30,11 +30,15 @@
 #include "gsm-app.h"
 #include "org.gnome.SessionManager.App.h"
 
+/* If a component crashes twice within a minute, we count that as a fatal error */
+#define _GSM_APP_RESPAWN_RATELIMIT_SECONDS 60
+
 typedef struct {
         char            *id;
         char            *app_id;
         int              phase;
         char            *startup_id;
+        gint64           last_restart_time;
         GDBusConnection *connection;
         GsmExportedApp  *skeleton;
 } GsmAppPrivate;
@@ -522,8 +526,23 @@ gsm_app_restart (GsmApp  *app,
                  GError **error)
 {
         GsmAppPrivate *priv;
+        gint64         current_time;
 
         priv = gsm_app_get_instance_private (app);
+
+        current_time = g_get_real_time ();
+
+        if (priv->last_restart_time > 0
+            && (current_time - priv->last_restart_time) < _GSM_APP_RESPAWN_RATELIMIT_SECONDS * G_USEC_PER_SEC) {
+                g_warning ("App '%s' respawning too quickly", priv->app_id ? priv->app_id : priv->id);
+                g_set_error (error,
+                             GSM_APP_ERROR,
+                             GSM_APP_ERROR_GENERAL,
+                             "Component '%s' crashing too quickly",
+                             priv->app_id ? priv->app_id : priv->id);
+                return FALSE;
+        }
+        priv->last_restart_time = current_time;
 
         g_debug ("Re-starting app: %s", priv->id);
 


### PR DESCRIPTION
When a non-client app with AutoRestart enabled exits immediately after starting, the restart logic would loop without delay, causing high CPU usage. This adds a 60-second rate limit to gsm_app_restart. If an app respawns twice within this window, the second restart is rejected.

The code is adapted from:
- https://gitlab.gnome.org/GNOME/gnome-session/-/commit/4df48234
- https://gitlab.gnome.org/GNOME/gnome-session/-/commit/b9aa675e

Fixes #336